### PR TITLE
Fixes for setting namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.10
+
+* Fix running py-spy inside a docker container [#68](https://github.com/benfred/py-spy/issues/68)
+
 ## v0.1.9
 
 * Fix partial stack traces from showing up, by pausing process while collecting samples [#56](https://github.com/benfred/py-spy/issues/56). Also add a ```--nonblocking``` option to use previous behaviour of not stopping process.

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -385,7 +385,13 @@ impl PythonProcessInfo {
         // on linux, support profiling processes running in docker containers by setting
         // the namespace to match that of the target process when reading in binaries
         #[cfg(target_os="linux")]
-        let _namespace = process::Namespace::new(pid)?;
+        let _namespace = match process::Namespace::new(pid) {
+            Ok(ns) => Some(ns),
+            Err(e) => {
+                warn!("Failed to set namespace: {}", e);
+                None
+            }
+        };
 
         // parse the main python binary
         let (python_binary, python_filename) = {


### PR DESCRIPTION
We were trying to change the namespace even when it wasn't necessary,
causing issues like https://github.com/benfred/py-spy/issues/68.

Fix by comparing the target processes namespace to ours by reading the
softlinks appropiately, and also just logging a warning if we failed
to set the namespace if we failed for any reason.