### PR TITLE
Output stacks in order they were encountered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "indicatif"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +391,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,6 +810,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum goblin 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c65cd533b33e3d04c6e393225fa8919ddfcf5862ca8919c7f9a167c312ef41c2"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum indicatif 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fb831cf2537b05b856bab08c5c91c473821c4bb5fc1ec7749c227e2005ef121"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tempfile = "3.0.3"
 benfred-read-process-memory = "0.1.3"
 proc-maps = "0.1"
 memmap = "0.7.0"
+indexmap = "1.0.2"
 
 [target.'cfg(unix)'.dependencies]
 termios = "0.2.2"

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -27,7 +27,7 @@ SOFTWARE.
 */
 
 use std;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::io::Write;
 use std::fs::File;
 use std::path::Path;
@@ -41,13 +41,13 @@ use stack_trace::StackTrace;
 const FLAMEGRAPH_SCRIPT: &[u8] = include_bytes!("../vendor/flamegraph/flamegraph.pl");
 
 pub struct Flamegraph {
-    pub counts: HashMap<Vec<u8>, usize>,
+    pub counts: IndexMap<Vec<u8>, usize>,
     pub show_linenumbers: bool,
 }
 
 impl Flamegraph {
     pub fn new(show_linenumbers: bool) -> Flamegraph {
-        Flamegraph { counts: HashMap::new(), show_linenumbers }
+        Flamegraph { counts: IndexMap::new(), show_linenumbers }
     }
 
     pub fn increment(&mut self, traces: &[StackTrace]) -> std::io::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ extern crate nix;
 #[macro_use]
 extern crate log;
 extern crate memmap;
+extern crate indexmap;
 extern crate proc_maps;
 extern crate benfred_read_process_memory as read_process_memory;
 extern crate regex;


### PR DESCRIPTION
This change makes stack order deterministic, preserving the order they were first encountered. Then, this "natural" order can be considered when building the actual flame graph.
