### PR TITLE
Add methods for returning thread activity

### DIFF
--- a/remoteprocess/README.md
+++ b/remoteprocess/README.md
@@ -1,4 +1,4 @@
-remoteproces
+remoteprocess
 =====
 
 This crate provides a cross platform way of querying information about other processes running on

--- a/remoteprocess/examples/validate_libunwind.rs
+++ b/remoteprocess/examples/validate_libunwind.rs
@@ -24,7 +24,9 @@ fn libunwind_compare(pid: remoteprocess::Pid) -> Result<(), remoteprocess::Error
 
     let _lock = process.lock()?;
 
-    let mut gimli_cursor = unwinder.cursor(nix::unistd::Pid::from_raw(pid))?;
+    let thread = remoteprocess::Thread::new(pid);
+
+    let mut gimli_cursor = unwinder.cursor(&thread)?;
     let mut libunwind_cursor = libunwinder.cursor(pid)?;
 
     loop {

--- a/remoteprocess/src/dwarf_unwind.rs
+++ b/remoteprocess/src/dwarf_unwind.rs
@@ -119,7 +119,7 @@ impl UnwindInfo {
     #[cfg(target_os="macos")]
     fn get_fde(&self, pc: u64) -> gimli::Result<&FrameDescriptionEntry> {
         // Binary search frame description table to get the FDE on osx
-        if self.frame_descriptions.len() == 0 {
+        if self.frame_descriptions.is_empty() {
             return Err(gimli::Error::NoUnwindInfoForAddress);
         }
         let fde = match self.frame_descriptions.binary_search_by(|e| e.0.cmp(&pc)) {

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -9,7 +9,7 @@ use utils::{copy_pointer};
 #[derive(Debug)]
 pub struct StackTrace {
     pub thread_id: u64,
-    pub os_thread_id: Option<::remoteprocess::Tid>,
+    pub os_thread_id: Option<u64>,
     pub active: bool,
     pub owns_gil: bool,
     pub frames: Vec<Frame>


### PR DESCRIPTION
As part of https://github.com/benfred/py-spy/issues/92, this adds methods
to determine if a thread is idle. This also refactors threads into a struct
with common methods across operating systems (id, active, lock etc).