### PR TITLE
Use irregular sampling interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-maps 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "remoteprocess 0.1.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tempfile = "3.0.3"
 proc-maps = "0.1"
 memmap = "0.7.0"
 cpp_demangle = "0.2.12"
+rand = "0.6"
 remoteprocess = {path="./remoteprocess"}
 
 [target.'cfg(unix)'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ extern crate termios;
 #[cfg(windows)]
 extern crate winapi;
 extern crate cpp_demangle;
+extern crate rand;
 extern crate remoteprocess;
 
 mod config;
@@ -99,7 +100,7 @@ fn sample_console(process: &mut PythonSpy,
                                          &format!("{}", process.version),
                                          1.0 / rate as f64)?;
 
-    for sleep in utils::Timer::new(Duration::from_nanos(1_000_000_000 / rate)) {
+    for sleep in utils::Timer::new(rate as f64) {
         if let Err(elapsed) = sleep {
             console.increment_late_sample(elapsed);
         }
@@ -145,7 +146,7 @@ fn sample_flame(process: &mut PythonSpy, filename: &str, config: &config::Config
 
     let mut exit_message = "";
 
-    for sleep in utils::Timer::new(Duration::from_nanos(1_000_000_000 / config.sampling_rate)) {
+    for sleep in utils::Timer::new(config.sampling_rate as f64) {
         if let Err(delay) = sleep {
             if delay > Duration::from_secs(1) {
                 // TODO: once this available on crates.io https://github.com/mitsuhiko/indicatif/pull/41

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -24,7 +24,7 @@ pub struct Frame {
 }
 
 /// Given an InterpreterState, this function returns a vector of stack traces for each thread
-pub fn get_stack_traces<I, P>(interpreter: &I, process: &P  ) -> Result<(Vec<StackTrace>), Error>
+pub fn get_stack_traces<I, P>(interpreter: &I, process: &P) -> Result<(Vec<StackTrace>), Error>
         where I: InterpreterState, P: ProcessMemory {
     let mut ret = Vec::new();
     let mut threads = interpreter.head();


### PR DESCRIPTION
As suggested in #94, use an irregular sampling strategy to avoid potentially incorrect
results from sampling. Instead sample using a exponential distributrion.