### PR TITLE
Add travisci config for ARM

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,28 +7,35 @@ matrix:
     - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-musl
+    - env: TARGET=armv7-unknown-linux-gnueabihf
     - env: TARGET=x86_64-apple-darwin
       os: osx
 
 before_install:
 - |
   rustup target add $TARGET
-  # download libunwind and build a static version w/ musl-gcc if needed
   if [ $TARGET = x86_64-unknown-linux-musl ]; then
+      sudo apt-get install musl-tools
+      # download libunwind and build a static version w/ musl-gcc
       wget https://github.com/libunwind/libunwind/releases/download/v1.3.1/libunwind-1.3.1.tar.gz
       tar -zxvf libunwind-1.3.1.tar.gz
       cd libunwind-1.3.1/
       CC=musl-gcc ./configure --disable-minidebuginfo --enable-ptrace --disable-tests --disable-documentation
       make
       sudo make install
+  elif [ $TARGET = x86_64-unknown-linux-gnu ]; then
+      sudo apt-get install libunwind-dev
+  elif [ $TARGET = armv7-unknown-linux-gnueabihf ]; then
+      sudo apt-get install gcc-arm-linux-gnueabihf  gcc-5-multilib-arm-linux-gnueabihf libc-dev-armhf-cross
+  elif [ $TARGET = i686-unknown-linux-gnu ]; then
+      sudo apt-get install gcc-multilib
   fi
 
 script:
-  - cargo test --verbose --target $TARGET
-
-addons:
-  apt:
-    packages:
-    - libunwind-dev
-    - g++-multilib
-    - musl-tools
+- |
+  if [ $TARGET = armv7-unknown-linux-gnueabihf ]; then
+    # we can't run the unittest w/ ARM so just test that we can compile
+    cargo build --verbose --target $TARGET
+  else
+    cargo test --verbose --target $TARGET
+  fi


### PR DESCRIPTION
Add travisci config that ensures we can build against ARM processors, by cross compiling against the armv7-unknown-linux-gnueabihf target.

This doesn't let us run the unittests, but we can at least check that the py-spy builds against an arm target, and will prevent things like  https://github.com/benfred/py-spy/issues/89 from happening again.