### PR TITLE
Use Cargo.toml values for clap app parameters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,6 @@ serialize =
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:src/config.rs]
-
 [bumpversion:file:Cargo.toml]
 search = name = "py-spy"
 	version = "{current_version}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,9 +22,9 @@ impl Config {
         // we don't yet support native tracing on 32 bit linux
         let allow_native = !cfg!(all(target_os="linux", target_pointer_width="32"));
 
-        let matches = App::new("py-spy")
-            .version("0.2.0.dev0")
-            .about("A sampling profiler for Python programs")
+        let matches = App::new(crate_name!())
+            .version(crate_version!())
+            .about(crate_description!())
             .arg(Arg::with_name("function")
                 .short("F")
                 .long("function")


### PR DESCRIPTION
Instead of duplicating the information like version, appname and
description, just use the values provided by the Cargo.toml file.