### PR TITLE
Retrieve symbols for binaries missing eh_frame_hdr

### DIFF
--- a/src/cython.rs
+++ b/src/cython.rs
@@ -55,7 +55,7 @@ impl SourceMaps {
         let map = match SourceMap::new(&frame.filename, &frame.module) {
             Ok(map) => map,
             Err(e) => {
-                warn!("Failed to load cython file {}: {:?}", &frame.filename, e);
+                info!("Failed to load cython file {}: {:?}", &frame.filename, e);
                 self.maps.insert(frame.filename.clone(), None);
                 return;
             }

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -148,7 +148,7 @@ impl NativeStack {
                         },
                         None => {
                             merged.push(Frame{filename: frame.module.clone(),
-                                              name: format!("0x{:X}", addr),
+                                              name: format!("0x{:x}", addr),
                                               line: 0, short_filename: None, module: Some(frame.module.clone())})
                         }
                     }
@@ -159,7 +159,7 @@ impl NativeStack {
                 }
                 // if we can't symbolicate, just insert a stub here.
                 merged.push(Frame{filename: "?".to_owned(),
-                                  name: format!("0x{:X}", addr),
+                                  name: format!("0x{:x}", addr),
                                   line: 0, short_filename: None, module: None});
             });
         }

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -573,7 +573,7 @@ impl PythonProcessInfo {
         let maps = get_process_maps(process.pid)?;
         info!("Got virtual memory maps from pid {}:", process.pid);
         for map in &maps {
-            info!("map: {:016x}-{:016x} {}{}{} {}", map.start(), map.start() + map.size(),
+            debug!("map: {:016x}-{:016x} {}{}{} {}", map.start(), map.start() + map.size(),
                 if map.is_read() {'r'} else {'-'}, if map.is_write() {'w'} else {'-'}, if map.is_exec() {'x'} else {'-'},
                 map.filename().as_ref().unwrap_or(&"".to_owned()));
         }
@@ -666,7 +666,7 @@ impl PythonProcessInfo {
 
                     for dyld in &dyld_infos {
                         let segname = unsafe { std::ffi::CStr::from_ptr(dyld.segment.segname.as_ptr()) };
-                        info!("dyld: {:016x}-{:016x} {:10} {}",
+                        debug!("dyld: {:016x}-{:016x} {:10} {}",
                             dyld.segment.vmaddr, dyld.segment.vmaddr + dyld.segment.vmsize,
                             segname.to_string_lossy(), dyld.filename);
                     }


### PR DESCRIPTION
On anaconda 3.7.2, the libmkl_vml_avx512.so file doesn't contain an
eh_frame_hdr section. This was causing us to fail to load the binary,
and causing any addresses from there to display as '?'. This also
caused us to continually try to reload the list of binaries even
if not necessary.

Fix by unwind_info optional (falling back to libunwind in this case).