### PR TITLE
Add support for writing out Speedscope files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.2.0 (pre-release)
+
+* Add ability to profile native python extensions [#2](https://github.com/benfred/py-spy/issues/2)
+* Add FreeBSD support [#112](https://github.com/benfred/py-spy/issues/112)
+* Add option to write out Speedscope files [#115](https://github.com/benfred/py-spy/issues/115)
+* Add option to output raw call stack data [#35](https://github.com/benfred/py-spy/issues/35)
+* Get thread idle status from OS [#92](https://github.com/benfred/py-spy/issues/92)
+* Allow use as a library by other rust programs [#110](https://github.com/benfred/py-spy/issues/110)
+* Show OS threadids in --dump [#57](https://github.com/benfred/py-spy/issues/57)
+* Drop root permissions when starting new process [#116](https://github.com/benfred/py-spy/issues/116)
+* Support building for ARM procesesors [#89](https://github.com/benfred/py-spy/issues/89)
+
 ## v0.1.11
 
 * Fix to detect GIL status on Python 3.7+ [#104](https://github.com/benfred/py-spy/pull/104)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -730,6 +731,9 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "remoteprocess 0.1.0",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -944,6 +948,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +993,31 @@ dependencies = [
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "shlex"
@@ -1065,6 +1099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1140,7 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1312,12 +1357,16 @@ dependencies = [
 "checksum rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "4f089652ca87f5a82a62935ec6172a534066c7b97be003cc8f702ee9a7a59c92"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
 "checksum scroll_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1aa96c45e7f5a91cb7fabe7b279f02fea7126239fc40b732316e8b6a2d0fcb"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
+"checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
+"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
@@ -1328,6 +1377,7 @@ dependencies = [
 "checksum syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)" = "8b4f551a91e2e3848aeef8751d0d4eec9489b6474c720fd4c55958d8d31a430c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
+"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0"
 build="build.rs"
 
 [dependencies]
-clap = "2"
+clap = {version="2", features=["wrap_help"]}
 console = "0.7"
 ctrlc = "3"
 indicatif = "0.11"
@@ -28,6 +28,9 @@ tempfile = "3.0.3"
 proc-maps = "0.1.6"
 memmap = "0.7.0"
 cpp_demangle = "0.2.12"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
 rand = "0.6"
 remoteprocess = {path="./remoteprocess", version="0.1.0"}
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Not yet =).
 ## Credits
 
 py-spy is heavily inspired by [Julia Evans](https://github.com/jvns/) excellent work on [rbspy](http://github.com/rbspy/rbspy).
-In particular, the code to generate the flamegraphs is taken directly from rbspy, and this project uses the
+In particular, the code to generate flamegraph and speedscope files is taken directly from rbspy, and this project uses the
 [read-process-memory](https://github.com/luser/read-process-memory) and [proc-maps](https://github.com/benfred/proc-maps) crates that were spun off from rbspy.
 
 ## License

--- a/examples/native_stress_test.rs
+++ b/examples/native_stress_test.rs
@@ -33,7 +33,6 @@ fn native_stress_test(pid: remoteprocess::Pid) -> Result<(), failure::Error> {
            }
         }
     }
-    Ok(())
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ extern crate termios;
 extern crate winapi;
 extern crate cpp_demangle;
 extern crate rand;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
 extern crate remoteprocess;
 
 mod config;
@@ -39,8 +44,9 @@ mod python_spy;
 mod stack_trace;
 mod console_viewer;
 mod flamegraph;
-mod utils;
+mod speedscope;
 mod timer;
+mod utils;
 mod version;
 
 use std::io::Read;
@@ -53,6 +59,7 @@ use failure::Error;
 use python_spy::PythonSpy;
 use stack_trace::StackTrace;
 use console_viewer::ConsoleViewer;
+use config::{Config, FileFormat};
 
 fn print_traces(traces: &[StackTrace], show_idle: bool) {
     for trace in traces {
@@ -95,7 +102,7 @@ fn permission_denied(err: &Error) -> bool {
 
 fn sample_console(process: &mut PythonSpy,
                   display: &str,
-                  config: &config::Config) -> Result<(), Error> {
+                  config: &Config) -> Result<(), Error> {
     let rate = config.sampling_rate;
     let mut console = ConsoleViewer::new(config.show_line_numbers, display,
                                          &format!("{}", process.version),
@@ -124,11 +131,59 @@ fn sample_console(process: &mut PythonSpy,
     Ok(())
 }
 
+pub trait Recorder {
+    fn increment(&mut self, traces: &[StackTrace]) -> Result<(), Error>;
+    fn write(&self, w: &mut std::fs::File) -> Result<(), Error>;
+}
 
-fn sample_flame(process: &mut PythonSpy, filename: &str, config: &config::Config) -> Result<(), Error> {
+impl Recorder for speedscope::Stats {
+    fn increment(&mut self, traces: &[StackTrace]) -> Result<(), Error> {
+        for trace in traces {
+            self.record(trace)?;
+        }
+        Ok(())
+    }
+    fn write(&self, w: &mut std::fs::File) -> Result<(), Error> {
+        self.write(w)
+    }
+}
+
+impl Recorder for flamegraph::Flamegraph {
+    fn increment(&mut self, traces: &[StackTrace]) -> Result<(), Error> {
+        Ok(self.increment(traces)?)
+    }
+    fn write(&self, w: &mut std::fs::File) -> Result<(), Error> {
+        self.write(w)
+    }
+}
+
+pub struct RawFlamegraph(flamegraph::Flamegraph);
+
+impl Recorder for RawFlamegraph {
+    fn increment(&mut self, traces: &[StackTrace]) -> Result<(), Error> {
+        Ok(self.0.increment(traces)?)
+    }
+
+    fn write(&self, w: &mut std::fs::File) -> Result<(), Error> {
+        self.0.write_raw(w)
+    }
+}
+
+fn record_samples(process: &mut PythonSpy, config: &Config) -> Result<(), Error> {
     let max_samples = config.duration * config.sampling_rate;
 
-    let mut flame = flamegraph::Flamegraph::new(config.show_line_numbers);
+    let mut output: Box<dyn Recorder> = match config.format {
+        Some(FileFormat::flamegraph) => Box::new(flamegraph::Flamegraph::new(config.show_line_numbers)),
+        Some(FileFormat::speedscope) =>  Box::new(speedscope::Stats::new()),
+        Some(FileFormat::raw) => Box::new(RawFlamegraph(flamegraph::Flamegraph::new(config.show_line_numbers))),
+        None => return Err(format_err!("A file format is required to record samples"))
+    };
+
+    let filename = match config.filename.as_ref() {
+        Some(filename) => filename,
+        None => return Err(format_err!("A filename is required to record samples"))
+    };
+
     use indicatif::ProgressBar;
     let progress = ProgressBar::new(max_samples);
 
@@ -166,7 +221,7 @@ fn sample_flame(process: &mut PythonSpy, filename: &str, config: &config::Config
 
         match process.get_stack_traces() {
             Ok(traces) => {
-                flame.increment(&traces)?;
+                output.increment(&traces)?;
                 samples += 1;
                 if samples >= max_samples {
                     break;
@@ -189,9 +244,11 @@ fn sample_flame(process: &mut PythonSpy, filename: &str, config: &config::Config
         println!("{}", exit_message);
     }
 
-    let out_file = std::fs::File::create(filename)?;
-    flame.write(out_file)?;
+    {
+    let mut out_file = std::fs::File::create(filename)?;
+    output.write(&mut out_file)?;
     println!("Wrote flame graph '{}'. Samples: {} Errors: {}", filename, samples, errors);
+    }
 
     // open generated flame graph in the browser on OSX (theory being that on linux
     // you might be SSH'ed into a server somewhere and this isn't desired, but on
@@ -202,8 +259,31 @@ fn sample_flame(process: &mut PythonSpy, filename: &str, config: &config::Config
     Ok(())
 }
 
+fn run_spy_command(process: &mut PythonSpy, config: &config::Config) -> Result<(), Error> {
+    match config.command.as_ref() {
+        "dump" =>  {
+            println!("{}\nPython version {}", process.process.exe()?, process.version);
+            print_traces(&process.get_stack_traces()?, true);
+        },
+        "record" => {
+            record_samples(process, config)?;
+        },
+        "top" => {
+            let display = match config.python_program.as_ref() {
+                Some(subprocess) => subprocess.join(" "),
+                None => format!("pid: {}", config.pid.unwrap())
+            };
+            sample_console(process, &display, config)?;
+        }
+        _ => {
+            // TODO: ?
+        }
+    }
+    Ok(())
+}
+
 fn pyspy_main() -> Result<(), Error> {
-    let config = config::Config::from_commandline()?;
+    let config = config::Config::from_commandline();
 
     #[cfg(target_os="macos")]
     {
@@ -216,14 +296,7 @@ fn pyspy_main() -> Result<(), Error> {
 
     if let Some(pid) = config.pid {
         let mut process = PythonSpy::retry_new(pid, &config, 3)?;
-        if config.dump {
-            println!("{}\nPython version {}", process.process.exe()?, process.version);
-            print_traces(&process.get_stack_traces()?, true);
-        } else if let Some(ref flame_file) = config.flame_file_name {
-            sample_flame(&mut process, &flame_file, &config)?;
-        } else {
-            sample_console(&mut process, &format!("pid: {}", pid), &config)?;
-        }
+        run_spy_command(&mut process, &config)?;
     }
 
     else if let Some(ref subprocess) = config.python_program {
@@ -257,11 +330,7 @@ fn pyspy_main() -> Result<(), Error> {
         }
         let result = match PythonSpy::retry_new(command.id() as remoteprocess::Pid, &config, 8) {
             Ok(mut process) => {
-                if let Some(ref flame_file) = config.flame_file_name {
-                    sample_flame(&mut process, &flame_file, &config)
-                } else {
-                    sample_console(&mut process, &subprocess.join(" "), &config)
-                }
+                run_spy_command(&mut process, &config)
             },
             Err(e) => Err(e)
         };

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -56,7 +56,7 @@ impl PythonSpy {
 
         // lets us figure out which thread has the GIL
          let threadstate_address = match version {
-             Version{major: 3, minor: 7...8, ..} => {
+             Version{major: 3, minor: 7..=8, ..} => {
                 match python_info.get_symbol("_PyRuntime") {
                     Some(&addr) => {
                         if let Some(offset) = pyruntime::get_tstate_current_offset(&version) {
@@ -150,7 +150,7 @@ impl PythonSpy {
             Version{major: 3, minor: 4, ..} => self._get_stack_traces::<v3_5_5::_is>(),
             Version{major: 3, minor: 3, ..} => self._get_stack_traces::<v3_3_7::_is>(),
             // ABI for 2.3/2.4/2.5/2.6/2.7 is also compatible
-            Version{major: 2, minor: 3...7, ..} => self._get_stack_traces::<v2_7_15::_is>(),
+            Version{major: 2, minor: 3..=7, ..} => self._get_stack_traces::<v2_7_15::_is>(),
             _ => Err(format_err!("Unsupported version of Python: {}", self.version)),
         }
     }
@@ -546,7 +546,7 @@ fn check_interpreter_addresses(addrs: &[usize],
         Version{major: 3, minor: 5, ..} => check::<v3_5_5::_is>(addrs, maps, process),
         Version{major: 3, minor: 4, ..} => check::<v3_5_5::_is>(addrs, maps, process),
         Version{major: 3, minor: 3, ..} => check::<v3_3_7::_is>(addrs, maps, process),
-        Version{major: 2, minor: 3...7, ..} => check::<v2_7_15::_is>(addrs, maps, process),
+        Version{major: 2, minor: 3..=7, ..} => check::<v2_7_15::_is>(addrs, maps, process),
         _ => Err(format_err!("Unsupported version of Python: {}", version))
     }
 }

--- a/src/speedscope.rs
+++ b/src/speedscope.rs
@@ -1,0 +1,212 @@
+// This code is adapted from rbspy:
+// https://github.com/rbspy/rbspy/tree/master/src/ui/speedscope.rs
+// licensed under the MIT License:
+/*
+MIT License
+
+Copyright (c) 2016 Julia Evans, Kamal Marhubi
+Portions (continuous integration setup) Copyright (c) 2016 Jorge Aparicio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+use std::collections::{HashMap};
+use std::io;
+use std::io::Write;
+use std::fs::File;
+
+use crate::stack_trace;
+use remoteprocess::Tid;
+
+use failure::{Error};
+use serde_json;
+
+/*
+ * This file contains code to export rbspy profiles for use in https://speedscope.app
+ *
+ * The TypeScript definitions that define this file format can be found here:
+ * https://github.com/jlfwong/speedscope/blob/9d13d9/src/lib/file-format-spec.ts
+ *
+ * From the TypeScript definition, a JSON schema is generated. The latest
+ * schema can be found here: https://speedscope.app/file-format-schema.json
+ *
+ * This JSON schema conveniently allows to generate type bindings for generating JSON.
+ * You can use https://app.quicktype.io/ to generate serde_json Rust bindings for the
+ * given JSON schema.
+ *
+ * There are multiple variants of the file format. The variant we're going to generate
+ * is the "type: sampled" profile, since it most closely maps to rbspy's data recording
+ * structure.
+ */
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SpeedscopeFile {
+    #[serde(rename = "$schema")]
+    schema: String,
+    profiles: Vec<Profile>,
+    shared: Shared,
+
+    #[serde(rename = "activeProfileIndex")]
+    active_profile_index: Option<f64>,
+
+    exporter: Option<String>,
+
+    name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Profile {
+    #[serde(rename = "type")]
+    profile_type: ProfileType,
+
+    name: String,
+    unit: ValueUnit,
+
+    #[serde(rename = "startValue")]
+    start_value: f64,
+
+    #[serde(rename = "endValue")]
+    end_value: f64,
+
+    samples: Vec<Vec<usize>>,
+    weights: Vec<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Shared {
+    frames: Vec<Frame>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Frame {
+    name: String,
+    file: Option<String>,
+    line: Option<u32>,
+    col: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum ProfileType {
+    #[serde(rename = "evented")]
+    Evented,
+    #[serde(rename = "sampled")]
+    Sampled,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum ValueUnit {
+    #[serde(rename = "bytes")]
+    Bytes,
+    #[serde(rename = "microseconds")]
+    Microseconds,
+    #[serde(rename = "milliseconds")]
+    Milliseconds,
+    #[serde(rename = "nanoseconds")]
+    Nanoseconds,
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "seconds")]
+    Seconds,
+}
+
+impl SpeedscopeFile {
+  pub fn new(samples: &HashMap<Tid, Vec<Vec<usize>>>, frames: &Vec<Frame>) -> SpeedscopeFile {
+    let end_value = samples.len();
+
+    SpeedscopeFile {
+      // This is always the same
+      schema: "https://www.speedscope.app/file-format-schema.json".to_string(),
+
+      active_profile_index: None,
+
+      name: Some("py-spy profile".to_string()),
+
+      exporter: Some(format!("py-spy@{}", env!("CARGO_PKG_VERSION"))),
+
+      profiles: samples.iter().map(|(_, samples)| {
+        let weights: Vec<f64> = (&samples).iter().map(|_s| 1_f64).collect();
+
+        Profile {
+            profile_type: ProfileType::Sampled,
+            name: String::from("py-spy"),
+            unit: ValueUnit::None,
+            start_value: 0.0,
+            end_value: end_value as f64,
+            samples: samples.clone(),
+            weights
+        }
+      }).collect(),
+
+      shared: Shared {
+          frames: frames.clone()
+      }
+    }
+  }
+}
+
+impl Frame {
+    pub fn new(stack_frame: &stack_trace::Frame) -> Frame {
+        Frame {
+            name: stack_frame.name.clone(),
+            // TODO: filename?
+            file: Some(stack_frame.filename.clone()),
+            line: Some(stack_frame.line as u32),
+            col: None
+        }
+    }
+}
+
+pub struct Stats {
+    samples: HashMap<Tid, Vec<Vec<usize>>>,
+    frames: Vec<Frame>,
+    frame_to_index: HashMap<stack_trace::Frame, usize>
+}
+
+impl Stats {
+    pub fn new() -> Stats {
+        Stats {
+            samples: HashMap::new(),
+            frames: vec![],
+            frame_to_index: HashMap::new()
+        }
+    }
+
+    pub fn record(&mut self, stack: &stack_trace::StackTrace) -> Result<(), io::Error> {
+        let mut frame_indices: Vec<usize> = stack.frames.iter().map(|frame| {
+            let frames = &mut self.frames;
+            *self.frame_to_index.entry(frame.clone()).or_insert_with(|| {
+                let len = frames.len();
+                frames.push(Frame::new(&frame));
+                len
+            })
+        }).collect();
+        frame_indices.reverse();
+
+        self.samples.entry(stack.thread_id as Tid).or_insert_with(|| {
+            vec![]
+        }).push(frame_indices);
+        Ok(())
+    }
+
+    pub fn write(&self, w: &mut File) -> Result<(), Error> {
+        let json = serde_json::to_string(&SpeedscopeFile::new(&self.samples, &self.frames))?;
+        writeln!(w, "{}", json)?;
+        Ok(())
+    }
+}

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -6,7 +6,7 @@ use remoteprocess::ProcessMemory;
 use crate::python_interpreters::{InterpreterState, ThreadState, FrameObject, CodeObject, StringObject, BytesObject};
 
 /// Call stack for a single python thread
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StackTrace {
     /// The python thread id for this stack trace
     pub thread_id: u64,


### PR DESCRIPTION
This adds support for writing out speedscope files, as well as writing out raw
call stack data. The speedscope code is adapted from rbspy.

This change also refactors the commandline arguments significantly, changing
to take subcommands (```py-spy dump -p 1234```) instead of flags. While this
is a breaking change, I think it is a better long term solution for py-spy -
 and it makes more sense for the '-f' flag to be the file format and '-o'
to be the filename (which would have broken commandline compatability anyways).