### PR TITLE
publish freebsd tarball on release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,11 +6,14 @@ freebsd_task:
   env:
     matrix:
       - TOOLCHAIN: stable
+    GITHUB_TOKEN: ENCRYPTED[67283c0b5c9880ac3b7d8fb0335c4b24f95c62dab30b5379dca192600801c380a41f7436c7daaebfaa8f1381237a8412]
   setup_script:
-    - pkg install -y curl
+    - pkg install -y curl bash
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --default-toolchain $TOOLCHAIN
   build_script:
-    - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo build --verbose
+    - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo build --verbose --release
   test_script:
-    - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo test --verbose
+    - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo test --verbose --release
+  publish_script:
+    - bash ./ci/publish_freebsd.sh

--- a/ci/publish_freebsd.sh
+++ b/ci/publish_freebsd.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -ex
+
+if [[ "$CIRRUS_RELEASE" == "" ]]; then
+  echo "Not a release. No need to deploy!"
+  exit 0
+fi
+
+if [[ "$GITHUB_TOKEN" == "" ]]; then
+  echo "Please provide GitHub access token via GITHUB_TOKEN environment variable!"
+  exit 1
+fi
+
+file_content_type="application/octet-stream"
+fpath=py-spy-$CIRRUS_TAG-x86_64-freebsd.tar.gz
+
+tar czf $fpath ./target/release/py-spy
+
+echo "Uploading $fpath..."
+name=$(basename "$fpath")
+url_to_upload="https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=$name"
+curl -X POST \
+--data-binary @$fpath \
+--header "Authorization: token $GITHUB_TOKEN" \
+--header "Content-Type: $file_content_type" \
+$url_to_upload


### PR DESCRIPTION
Change to have cirrus ci to push a tarball to the github releases page on tags