### PR TITLE
Don't include parent directories of py-spy binary for FreeBSD releases

### DIFF
--- a/ci/publish_freebsd.sh
+++ b/ci/publish_freebsd.sh
@@ -14,7 +14,7 @@ fi
 file_content_type="application/octet-stream"
 fpath=py-spy-$CIRRUS_TAG-x86_64-freebsd.tar.gz
 
-tar czf $fpath ./target/release/py-spy
+tar -C ./target/release -czf $fpath py-spy
 
 echo "Uploading $fpath..."
 name=$(basename "$fpath")


### PR DESCRIPTION
[Current](https://github.com/benfred/py-spy/releases/download/v0.2.0.dev3/py-spy-v0.2.0.dev3-x86_64-freebsd.tar.gz) artifact ships `py-spy` binary within `./target/release` directory while others don't.