### PR TITLE
Fix thread activity for i686/ARM/FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ freebsd_task:
       - TOOLCHAIN: stable
     GITHUB_TOKEN: ENCRYPTED[67283c0b5c9880ac3b7d8fb0335c4b24f95c62dab30b5379dca192600801c380a41f7436c7daaebfaa8f1381237a8412]
   setup_script:
-    - pkg install -y curl bash
+    - pkg install -y curl bash python
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --default-toolchain $TOOLCHAIN
   build_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ script:
   if [ $TARGET = armv7-unknown-linux-gnueabihf ]; then
     # we can't run the unittest w/ ARM so just test that we can compile
     cargo build --verbose --target $TARGET
+  elif [ $TARGET = i686-unknown-linux-gnu ]; then
+    # doesn't seem like the integration tests work with i686 (building a 32bit version
+    # then using to profile a 64bit pythhon issus?). Just test we can compile
+    cargo build --verbose --target $TARGET
   else
     cargo test --verbose --target $TARGET
   fi
@@ -76,3 +80,11 @@ branches:
 notifications:
   email:
     on_success: never
+
+addons:
+  apt:
+    packages:
+    - python
+  homebrew:
+    packages:
+    - python

--- a/remoteprocess/src/lib.rs
+++ b/remoteprocess/src/lib.rs
@@ -155,7 +155,7 @@ impl std::error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::GimliError(ref e) => Some(e),
             Error::GoblinError(ref e) => Some(e),

--- a/remoteprocess/src/osx/compact_unwind.rs
+++ b/remoteprocess/src/osx/compact_unwind.rs
@@ -318,5 +318,5 @@ impl std::fmt::Display for CompactUnwindError {
 
 impl std::error::Error for CompactUnwindError {
     fn description(&self) -> &str { "CompactUnwindError" }
-    fn cause(&self) -> Option<&std::error::Error> { None }
+    fn cause(&self) -> Option<&dyn std::error::Error> { None }
 }

--- a/remoteprocess/src/osx/unwinder.rs
+++ b/remoteprocess/src/osx/unwinder.rs
@@ -87,7 +87,7 @@ impl Unwinder {
         Ok(Cursor{registers: thread.registers()?, parent: self, initial_frame: true})
     }
 
-    pub fn symbolicate(&self, addr: u64, _line_info: bool, callback: &mut FnMut(&StackFrame)) -> Result<(), Error> {
+    pub fn symbolicate(&self, addr: u64, _line_info: bool, callback: &mut dyn FnMut(&StackFrame)) -> Result<(), Error> {
         // Get the symbols for the current address
         let symbol = unsafe { self.cs.resolve(addr) };
 
@@ -208,7 +208,7 @@ impl<'a> Cursor<'a> {
 
         let check = |rip| {
             match rip {
-                0...0x1000 => None,
+                0..=0x1000 => None,
                 _ => Some(rip)
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Example:
 //!
 //! ```rust,no_run
-//! fn print_python_stacks(pid: remoteprocess::Pid) -> Result<(), failure::Error> {
+//! fn print_python_stacks(pid: py_spy::Pid) -> Result<(), failure::Error> {
 //!     // Create a new PythonSpy object with the default config options
 //!     let config = py_spy::Config::default();
 //!     let mut process = py_spy::PythonSpy::new(pid, &config)?;
@@ -64,4 +64,5 @@ pub use python_spy::PythonSpy;
 pub use config::Config;
 pub use stack_trace::StackTrace;
 pub use stack_trace::Frame;
+pub use remoteprocess::Pid;
 

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -206,7 +206,7 @@ impl PythonSpy {
 
             trace.active = match os_thread_id.map(|id| thread_activity.get(&id)) {
                 Some(Some(active)) => *active,
-                _ => self._heuristic_thread_activity(&trace)
+                _ => !self._heuristic_is_thread_idle(&trace)
             };
 
             for frame in &mut trace.frames {
@@ -226,7 +226,7 @@ impl PythonSpy {
 
     // heuristic fallback for determining if a thread is active, used
     // when we don't have the ability to get the thread information from the OS
-    fn _heuristic_thread_activity(&self, trace: &StackTrace) -> bool {
+    fn _heuristic_is_thread_idle(&self, trace: &StackTrace) -> bool {
         let frames = &trace.frames;
         if frames.is_empty() {
             true
@@ -780,6 +780,7 @@ pub fn is_python_framework(pathname: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[cfg(target_os="macos")]
     #[test]
     fn test_is_python_lib() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,77 @@
+extern crate py_spy;
+
+use py_spy::{Config, PythonSpy, Pid};
+
+struct TestRunner {
+    child: std::process::Child,
+    spy: PythonSpy
+}
+
+impl TestRunner {
+    fn new(filename: &str) -> TestRunner {
+        let mut child = std::process::Command::new("python").arg(filename).spawn().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        let config = Config::default();
+        let mut spy = PythonSpy::retry_new(child.id() as _, &config, 20).unwrap();
+
+        TestRunner{child, spy}
+    }
+}
+
+impl Drop for TestRunner {
+    fn drop(&mut self) {
+        self.child.kill().unwrap();
+    }
+}
+
+#[test]
+fn test_busy_loop() {
+    #[cfg(target_os="macos")]
+    {
+        // We need root permissions here to run this on OSX
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+    }
+    let mut runner = TestRunner::new("./tests/scripts/busyloop.py");
+    let traces = runner.spy.get_stack_traces().unwrap();
+
+    // we can't be guaranteed what line the script is processing, but
+    // we should be able to say that the script is active and
+    // catch issues like https://github.com/benfred/py-spy/issues/141
+    assert!(traces[0].active);
+}
+
+#[test]
+fn test_long_sleep() {
+    #[cfg(target_os="macos")]
+    {
+        // We need root permissions here to run this on OSX
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+    }
+
+    let mut runner = TestRunner::new("./tests/scripts/longsleep.py");
+
+    let traces = runner.spy.get_stack_traces().unwrap();
+    assert_eq!(traces.len(), 1);
+    let trace = &traces[0];
+
+    // Make sure the stack trace is what we expect
+    assert_eq!(trace.frames[0].name, "longsleep");
+    assert_eq!(trace.frames[0].filename, "./tests/scripts/longsleep.py");
+    assert_eq!(trace.frames[0].line, 5);
+
+    assert_eq!(trace.frames[1].name, "<module>");
+    assert_eq!(trace.frames[1].line, 9);
+    assert_eq!(trace.frames[0].filename, "./tests/scripts/longsleep.py");
+
+    assert!(!traces[0].owns_gil);
+
+    // we will only know this thread is sleeping in certain cases,
+    // and having unwind support is a reasonable proxy for that
+    #[cfg(unwind)]
+    assert!(!traces[0].active);
+}


### PR DESCRIPTION
The heuristic thread activity fallback was being called incorrectly, leading
to active threads being marked as idle.

Fix, and add a Rust integration test that would have caught this