### PR TITLE
disable native profiling on OSX

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,14 @@ fn main() {
     // copied from remoteprocess/build.rs because I couldn't find a way to share this
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
         "windows" => println!("cargo:rustc-cfg=unwind"),
-        "macos" => println!("cargo:rustc-cfg=unwind"),
+        "macos" => {
+            // OSX native profiling doesn't work all that well right now, and
+            // its broken enough that I don't want to support it at the moment.
+            // only enable if a specific env variable is set
+            if std::env::var("PYSPY_ALLOW_NATIVE_PROFILING").is_ok() {
+                println!("cargo:rustc-cfg=unwind");
+            }
+        },
         "linux" => {
             // We only support native unwinding on x86_64 linux
             if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64"{

--- a/remoteprocess/build.rs
+++ b/remoteprocess/build.rs
@@ -3,7 +3,14 @@ use std::env;
 fn main() {
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
         "windows" => println!("cargo:rustc-cfg=unwind"),
-        "macos" => println!("cargo:rustc-cfg=unwind"),
+        "macos" => {
+            // OSX native profiling doesn't work all that well right now, and
+            // its broken enough that I don't want to support it at the moment.
+            // only enable if a specific env variable is set
+            if std::env::var("PYSPY_ALLOW_NATIVE_PROFILING").is_ok() {
+                println!("cargo:rustc-cfg=unwind");
+            }
+        },
         "linux" => {
             // We only support native unwinding on x86_64 linux
             if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64"{

--- a/remoteprocess/src/lib.rs
+++ b/remoteprocess/src/lib.rs
@@ -76,7 +76,7 @@ extern crate libproc;
 #[cfg(windows)]
 extern crate winapi;
 
-#[cfg(target_os="macos")]
+#[cfg(all(target_os="macos", unwind))]
 #[macro_use]
 mod dylib;
 

--- a/remoteprocess/src/osx/mod.rs
+++ b/remoteprocess/src/osx/mod.rs
@@ -1,8 +1,10 @@
 #[doc(hidden)]
 pub mod compact_unwind;
 mod utils;
+#[cfg(unwind)]
 mod symbolication;
 mod mach_thread_bindings;
+#[cfg(unwwind)]
 mod unwinder;
 
 use std;
@@ -24,6 +26,7 @@ use mach::thread_status::x86_THREAD_STATE64;
 use mach::thread_act::{thread_get_state};
 
 pub use self::utils::{TaskLock, ThreadLock};
+#[cfg(unwwind)]
 pub use self::unwinder::Unwinder;
 
 use libproc::libproc::proc_pid::{pidpath, pidinfo, PIDInfo, PidInfoFlavor};
@@ -81,6 +84,7 @@ impl Process {
         Ok(ret)
     }
 
+    #[cfg(unwind)]
     pub fn unwinder(&self) -> Result<Unwinder, Error> {
         Ok(Unwinder::new(self.pid)?)
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -70,8 +70,7 @@ fn test_long_sleep() {
 
     assert!(!traces[0].owns_gil);
 
-    // we will only know this thread is sleeping in certain cases,
-    // and having unwind support is a reasonable proxy for that
-    #[cfg(unwind)]
+    // We don't have thread activity on freebsd or arm/i686 linux yet.
+    #[cfg(any(target_os="macos", target_os="windows", all(target_os="linux", target_pointer_width = "64")))]
     assert!(!traces[0].active);
 }


### PR DESCRIPTION
Native extension profiling on OSX doesn't work all that well yet. Disable.