### PR TITLE
add option to dump as JSON (+ other fixes)

### DIFF
--- a/remoteprocess/src/linux/mod.rs
+++ b/remoteprocess/src/linux/mod.rs
@@ -87,7 +87,6 @@ impl Process {
                 }
             }
         }
-
         Ok(Lock{locks})
     }
 
@@ -242,4 +241,6 @@ fn test_parse_stat() {
     assert_eq!(get_active_status(b")))"), None);
     assert_eq!(get_active_status(b"1234 (bash)S"), None);
     assert_eq!(get_active_status(b"1234)SSSS"), None);
+    assert_eq!(get_active_status(b"15379 (ipython) t 9898 15379 9898 34816", Some(b't')));
+
 }

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -19,6 +19,7 @@ pub struct BinaryInfo {
 }
 
 impl BinaryInfo {
+    #[cfg(unwind)]
     pub fn contains(&self, addr: u64) -> bool {
         addr >= self.addr && addr < (self.addr + self.size)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,8 @@ extern crate lru;
 extern crate memmap;
 extern crate proc_maps;
 extern crate regex;
-
+#[macro_use]
+extern crate serde_derive;
 #[cfg(windows)]
 extern crate winapi;
 extern crate cpp_demangle;

--- a/src/speedscope.rs
+++ b/src/speedscope.rs
@@ -55,7 +55,7 @@ use serde_json;
  * structure.
  */
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 struct SpeedscopeFile {
     #[serde(rename = "$schema")]
     schema: String,
@@ -70,7 +70,7 @@ struct SpeedscopeFile {
     name: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 struct Profile {
     #[serde(rename = "type")]
     profile_type: ProfileType,

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -1,12 +1,13 @@
 use std;
 
 use failure::{Error, ResultExt};
+
 use remoteprocess::ProcessMemory;
 
 use crate::python_interpreters::{InterpreterState, ThreadState, FrameObject, CodeObject, StringObject, BytesObject};
 
 /// Call stack for a single python thread
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct StackTrace {
     /// The python thread id for this stack trace
     pub thread_id: u64,
@@ -21,7 +22,7 @@ pub struct StackTrace {
 }
 
 /// Information about a single function call in a stack trace
-#[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Serialize)]
 pub struct Frame {
     /// The function name
     pub name: String,


### PR DESCRIPTION
This adds an option to dump the current stack traces as JSON data to stdout.
This will help out with scripting the output here.

Also fix minor display issues on windows:The background style was wrong after
bringing up the help menu, and the spinner during record was displaying
an invalid unicode symbol.

This also adds a cmdline implementations for both windows/freebsd.