### PR TITLE
linux pthreadid reuse fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,7 @@ fn record_samples(process: &mut PythonSpy, config: &Config) -> Result<(), Error>
                     exit_message = "Stopped sampling because the process ended";
                     break;
                 } else {
-                    warn!("Failed to get stack trace {:?}", e);
+                    warn!("Failed to get stack trace {}", e);
                     errors += 1;
                 }
             }
@@ -441,7 +441,7 @@ fn pyspy_main() -> Result<(), Error> {
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::builder().default_format_timestamp_nanos(true).try_init().unwrap();
 
     if let Err(err) = pyspy_main() {
         #[cfg(unix)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
 extern crate py_spy;
 
-use py_spy::{Config, PythonSpy, Pid};
+use py_spy::{Config, PythonSpy};
 
 struct TestRunner {
     child: std::process::Child,
@@ -8,12 +8,10 @@ struct TestRunner {
 }
 
 impl TestRunner {
-    fn new(filename: &str) -> TestRunner {
-        let mut child = std::process::Command::new("python").arg(filename).spawn().unwrap();
+    fn new(config: Config, filename: &str) -> TestRunner {
+        let child = std::process::Command::new("python").arg(filename).spawn().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(400));
-
-        let config = Config::default();
-        let mut spy = PythonSpy::retry_new(child.id() as _, &config, 20).unwrap();
+        let spy = PythonSpy::retry_new(child.id() as _, &config, 20).unwrap();
 
         TestRunner{child, spy}
     }
@@ -21,7 +19,9 @@ impl TestRunner {
 
 impl Drop for TestRunner {
     fn drop(&mut self) {
-        self.child.kill().unwrap();
+        if let Err(err) = self.child.kill() {
+            eprintln!("Failed to kill child process {}", err);
+        }
     }
 }
 
@@ -34,13 +34,40 @@ fn test_busy_loop() {
             return;
         }
     }
-    let mut runner = TestRunner::new("./tests/scripts/busyloop.py");
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/busyloop.py");
     let traces = runner.spy.get_stack_traces().unwrap();
 
     // we can't be guaranteed what line the script is processing, but
     // we should be able to say that the script is active and
     // catch issues like https://github.com/benfred/py-spy/issues/141
     assert!(traces[0].active);
+}
+
+#[cfg(unwind)]
+#[test]
+fn test_thread_reuse() {
+    // on linux we had an issue with the pthread -> native thread id caching
+    // the problem was that the pthreadids were getting re-used,
+    // and this caused errors on native unwind (since the native thread had
+    // exitted). Test that this works with a simple script that creates
+    // a couple short lived threads, and then profiling with native enabled
+    let config = Config{native: true, ..Default::default()};
+    let mut runner = TestRunner::new(config, "./tests/scripts/thread_reuse.py");
+
+    let mut errors = 0;
+
+    for _ in 0..100 {
+        // should be able to get traces here BUT we do sometimes get errors about
+        // not being able to suspend process ("No such file or directory (os error 2)"
+        // when threads exit. Allow a small number of errors here.
+        if let Err(e) = runner.spy.get_stack_traces() {
+            println!("Failed to get traces {}", e);
+            errors += 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+
+    assert!(errors <= 3);
 }
 
 #[test]
@@ -53,7 +80,7 @@ fn test_long_sleep() {
         }
     }
 
-    let mut runner = TestRunner::new("./tests/scripts/longsleep.py");
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/longsleep.py");
 
     let traces = runner.spy.get_stack_traces().unwrap();
     assert_eq!(traces.len(), 1);
@@ -70,7 +97,8 @@ fn test_long_sleep() {
 
     assert!(!traces[0].owns_gil);
 
-    // We don't have thread activity on freebsd or arm/i686 linux yet.
-    #[cfg(any(target_os="macos", target_os="windows", all(target_os="linux", target_pointer_width = "64")))]
+    // we should reliably be able to detect the thread is sleeping on osx/windows
+    // linux+freebsd is trickier
+    #[cfg(any(target_os="macos", target_os="windows"))]
     assert!(!traces[0].active);
 }

--- a/tests/scripts/thread_reuse.py
+++ b/tests/scripts/thread_reuse.py
@@ -1,0 +1,7 @@
+import time
+import threading
+
+while True:
+    th = threading.Thread(target = lambda: time.sleep(.5))
+    th.start()
+    th.join()


### PR DESCRIPTION
On linux, the python threadids are reused after the thread exits. This causes
issues with the cache of python thread -> native thread ids, since the
native thread id is different. With native extension profiling, this causes
errors when we try to get the native stack on a thread that has exitted.
This also will lead to incorrect results with the thread idle detection
code.

Fix and add a integration test to test this out. Also refactor the libunwind
code to return better error messages when this happens.