### PR TITLE
On FreeBSD warn about potential issues before allowing --pid

### DIFF
--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -853,7 +853,7 @@ mod tests {
         assert!(!is_python_lib("/lib/heapq.cpython-36m-darwin.dylib"));
     }
 
-    #[cfg(target_os="linux")]
+    #[cfg(any(target_os="linux", target_os="freebsd"))]
     #[test]
     fn test_is_python_lib() {
         // libpython bundled by pyinstaller https://github.com/benfred/py-spy/issues/42


### PR DESCRIPTION
On FreeBSD, profiling socket.connect on older versions of python can cause
the profiled process to throw an exception. Before allowing someone to profile
a running process, warn that this could happen and require them to set
an environment variable to acknowledge that this could happen.

https://github.com/benfred/py-spy/issues/147