### PR TITLE
Don't try to match threads for docker from host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.2.1
+
+* Fix issue with profiling dockerized process from the host os [#168](https://github.com/benfred/py-spy/issues/168)
+
 ## v0.2.0
 
 * Add ability to profile native python extensions [#2](https://github.com/benfred/py-spy/issues/2)

--- a/remoteprocess/src/linux/mod.rs
+++ b/remoteprocess/src/linux/mod.rs
@@ -196,6 +196,10 @@ impl Namespace {
             Ok(Namespace{ns_file: None})
         }
     }
+
+    pub fn is_set(self) -> bool {
+        self.ns_file.is_some()
+    }
 }
 
 impl Drop for Namespace {


### PR DESCRIPTION
When profiling a process inside a docker container from the Host OS, we fail to
unwind the native stack (which we use for figuring out the native thread id).
This caused an issue with the log being spammed with errors about this obscuring
the actual output (#168).

Fix by falling back to previous behaviour in this case, and also downgrade the
error message to a warning.