### PR TITLE
Fix integration_test on Windows

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,7 +9,7 @@ struct TestRunner {
 
 impl TestRunner {
     fn new(config: Config, filename: &str) -> TestRunner {
-        let child = std::process::Command::new("python3").arg(filename).spawn().unwrap();
+        let child = std::process::Command::new(if cfg!(windows) { "python" } else { "python3" }).arg(filename).spawn().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(400));
         let spy = PythonSpy::retry_new(child.id() as _, &config, 20).unwrap();
 


### PR DESCRIPTION
On my Windows 10 `python3` points to Windows Store app, not Python:

```
C:\>where python3
C:\Users\domar\AppData\Local\Microsoft\WindowsApps\python3.exe

C:\>where python
C:\Users\domar\AppData\Local\Programs\Python\Python37\python.exe
C:\Users\domar\AppData\Local\Microsoft\WindowsApps\python.exe
```