### PR TITLE
use python from the path for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ addons:
   apt:
     packages:
     - python3
+    - python
   homebrew:
     packages:
     - python

--- a/generate_bindings.py
+++ b/generate_bindings.py
@@ -128,6 +128,7 @@ def extract_bindings(cpython_path, version, configure=False):
             --whitelist-type PyStringObject \
             --whitelist-type PyTupleObject \
             --whitelist-type PyListObject \
+            --whitelist-type PyIntObject \
             --whitelist-type PyLongObject \
             --whitelist-type PyFloatObject \
             --whitelist-type PyDictObject \

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -75,7 +75,8 @@ pub fn print_traces(process: &mut PythonSpy, config: &Config) -> Result<(), Erro
                         shown_locals = true;
                     }
 
-                    let value = stringify_pyobject(&process.process, &process.version, local.addr, 128)?;
+                    let value = stringify_pyobject(&process.process, &process.version, local.addr, 128)
+                        .unwrap_or("?".to_owned());
                     println!("            {}: {}", local.name, value);
                 }
             }

--- a/src/python_bindings/v2_7_15.rs
+++ b/src/python_bindings/v2_7_15.rs
@@ -456,18 +456,14 @@ impl Default for _typeobject {
     }
 }
 pub type PyTypeObject = _typeobject;
-pub type Py_UNICODE = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct PyUnicodeObject {
+pub struct PyIntObject {
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut _typeobject,
-    pub length: Py_ssize_t,
-    pub str: *mut Py_UNICODE,
-    pub hash: ::std::os::raw::c_long,
-    pub defenc: *mut PyObject,
+    pub ob_ival: ::std::os::raw::c_long,
 }
-impl Default for PyUnicodeObject {
+impl Default for PyIntObject {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,7 +9,7 @@ struct TestRunner {
 
 impl TestRunner {
     fn new(config: Config, filename: &str) -> TestRunner {
-        let child = std::process::Command::new("python3").arg(filename).spawn().unwrap();
+        let child = std::process::Command::new("python").arg(filename).spawn().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(400));
         let spy = PythonSpy::retry_new(child.id() as _, &config, 20).unwrap();
 
@@ -149,7 +149,7 @@ fn test_unicode() {
     assert_eq!(traces.len(), 1);
     let trace = &traces[0];
 
-    assert_eq!(trace.frames[0].name, "sléép");
+    assert_eq!(trace.frames[0].name, "function1");
     assert_eq!(trace.frames[0].filename, "./tests/scripts/unicode💩.py");
     assert_eq!(trace.frames[0].line, 6);
 

--- a/tests/scripts/unicode💩.py
+++ b/tests/scripts/unicode💩.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 import time
 
-def sléép(seconds):
+def function1(seconds):
     time.sleep(seconds)
 
 if __name__ == "__main__":
-    sléép(100)
+    function1(100)


### PR DESCRIPTION
We used to require python3 for integration tests due to some
tests of the unicode functionality. Change to also let these
integration tests run against python2 by loosening this
requiremenet.