### PR TITLE
Remove deprecated "sudo" keywoard from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-sudo: required
 dist: xenial
 
 matrix:


### PR DESCRIPTION
cf
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

modified:   .travis.yml