### PR TITLE
#124 [WIP] Profile subprocesses

### DIFF
--- a/remoteprocess/src/linux/children.rs
+++ b/remoteprocess/src/linux/children.rs
@@ -1,0 +1,121 @@
+// This code is adapted from rbspy:
+// https://github.com/rbspy/rbspy/blob/3d09e3ced011eb10ab7a0f5906659820043e177e/src/ui/descendents.rs
+// licensed under the MIT License:
+/*
+MIT License
+
+Copyright (c) 2016 Julia Evans, Kamal Marhubi
+Portions (continuous integration setup) Copyright (c) 2016 Jorge Aparicio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+use std::collections::HashMap;
+use std::fs::read_dir;
+use std::fs::File;
+use std::io::Read;
+
+use super::{ Pid, Error };
+
+pub fn children(ppid: Pid) -> Result<Vec<Pid>, Error> {
+    let parents_to_children = map_parents_to_children()?;
+    get_children(ppid, parents_to_children)
+}
+
+fn get_children(
+    parent_pid: Pid,
+    parents_to_children: HashMap<Pid, Vec<Pid>>,
+) -> Result<Vec<Pid>, Error> {
+    let mut result = Vec::<Pid>::new();
+    let mut queue = Vec::<Pid>::new();
+    queue.push(parent_pid);
+
+    loop {
+        match queue.pop() {
+            None => {
+                return Ok(result);
+            }
+            Some(current_pid) => {
+                if let Some(children) = parents_to_children.get(&current_pid) {
+                    for child in children {
+                        queue.push(*child);
+                    }
+                }
+                result.push(current_pid);
+            }
+        }
+    }
+}
+
+fn map_parents_to_children() -> Result<HashMap<Pid, Vec<Pid>>, Error> {
+    let mut pid_map: HashMap<Pid, Vec<Pid>> = HashMap::new();
+
+    for (pid, ppid) in get_proc_children()? {
+        pid_map.entry(ppid).or_insert_with(|| vec![]).push(pid);
+    }
+    Ok(pid_map)
+}
+
+fn status_file_ppid(status: &str) -> Result<Pid, Error> {
+    let err = Error::Other(
+        format!("Failed to parse process status file {}", status)
+    );
+
+    status.split('\n')
+        .find(|x| x.starts_with("PPid:"))
+        .and_then(|line| {
+            let parts: Vec<&str> = line.split('\t').collect();
+            parts[1].parse::<Pid>().ok()
+        })
+        .ok_or(err)
+}
+
+#[cfg(target_os = "linux")]
+fn get_proc_children() -> Result<Vec<(Pid, Pid)>, Error> {
+    let mut process_pairs = vec![];
+    for entry in read_dir("/proc")? {
+        let entry = entry?;
+        // try parsing the directory name as a PID and see if it works
+        let maybe_pid = entry.file_name().to_string_lossy().parse::<Pid>();
+        if let Ok(pid) = maybe_pid {
+            let mut contents = String::new();
+            if let Ok(mut f) = File::open(entry.path().join("status")) {
+                f.read_to_string(&mut contents)?;
+                let ppid = status_file_ppid(&contents)?;
+                process_pairs.push((pid, ppid));
+            }
+        }
+    }
+    Ok(process_pairs)
+}
+
+#[test]
+fn test_get_children_depth_2() {
+    let mut map = HashMap::new();
+    map.insert(1, vec![2, 3]);
+    map.insert(2, vec![4]);
+    let desc = get_children(1, map).unwrap();
+    assert_eq!(desc, vec![1, 3, 2, 4]);
+}
+
+#[test]
+fn test_status_file_ppid() {
+    let status = "Name:	kthreadd\nState:	S (sleeping)\nTgid:	2\nNgid:	0\nPid:	0\nPPid:	1234\n";
+    assert_eq!(status_file_ppid(status).unwrap(), 1234)
+}

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -2,7 +2,7 @@ use std;
 
 use failure::{Error, ResultExt};
 
-use remoteprocess::ProcessMemory;
+use remoteprocess::{Process, ProcessMemory, Pid};
 
 use crate::python_interpreters::{InterpreterState, ThreadState, FrameObject, CodeObject, TupleObject};
 use crate::python_data_access::{copy_string, copy_bytes};
@@ -10,6 +10,8 @@ use crate::python_data_access::{copy_string, copy_bytes};
 /// Call stack for a single python thread
 #[derive(Debug, Clone, Serialize)]
 pub struct StackTrace {
+    /// The Python interpreter OS process id
+    pub process_id: Pid,
     /// The python thread id for this stack trace
     pub thread_id: u64,
     /// The OS thread id for this stack tracee
@@ -48,8 +50,8 @@ pub struct LocalVariable {
 }
 
 /// Given an InterpreterState, this function returns a vector of stack traces for each thread
-pub fn get_stack_traces<I, P>(interpreter: &I, process: &P) -> Result<(Vec<StackTrace>), Error>
-        where I: InterpreterState, P: ProcessMemory {
+pub fn get_stack_traces<I>(interpreter: &I, process: &Process) -> Result<(Vec<StackTrace>), Error>
+        where I: InterpreterState {
     // TODO: deprecate this method
     let mut ret = Vec::new();
     let mut threads = interpreter.head();
@@ -66,8 +68,8 @@ pub fn get_stack_traces<I, P>(interpreter: &I, process: &P) -> Result<(Vec<Stack
 }
 
 /// Gets a stack trace for an individual thread
-pub fn get_stack_trace<T, P >(thread: &T, process: &P, copy_locals: bool) -> Result<StackTrace, Error>
-        where T: ThreadState, P: ProcessMemory {
+pub fn get_stack_trace<T>(thread: &T, process: &Process, copy_locals: bool) -> Result<StackTrace, Error>
+        where T: ThreadState {
     // TODO: just return frames here? everything else probably should be returned out of scope
     let mut frames = Vec::new();
     let mut frame_ptr = thread.frame();
@@ -104,7 +106,12 @@ pub fn get_stack_trace<T, P >(thread: &T, process: &P, copy_locals: bool) -> Res
         frame_ptr = frame.back();
     }
 
-    Ok(StackTrace{frames, thread_id: thread.thread_id(), owns_gil: false, active: true, os_thread_id: None})
+    Ok(StackTrace{frames,
+                  process_id: process.pid,
+                  thread_id: thread.thread_id(),
+                  owns_gil: false,
+                  active: true,
+                  os_thread_id: None})
 }
 
 impl StackTrace {

--- a/tests/scripts/subprocesses.py
+++ b/tests/scripts/subprocesses.py
@@ -1,0 +1,22 @@
+import os
+import time
+import multiprocessing
+
+def child():
+    time.sleep(5000)
+
+def child_with_subchild():
+    subchild = multiprocessing.Process(target=child)
+    subchild.start()
+    time.sleep(5000)
+    subchild.join()
+
+if __name__ == "__main__":
+    first = multiprocessing.Process(target=child)
+    second = multiprocessing.Process(target=child_with_subchild)
+
+    first.start()
+    second.start()
+
+    first.join()
+    second.join()


### PR DESCRIPTION
It would be nice to be able to profile all the sub-processes of a
python process. This would let us profile programs that use
multiprocessing or gunicorn worker pools.

This change

* [py-spy] Adopts rbspy-like model of monitoring child processing via
  threads, communicating via mpsc channels.
* [remoteprocess] Borrows rbspy's process child detection
  functionality.