### PR TITLE
Include symbols from dynsym table of ELF bin/lib

### DIFF
--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -97,6 +97,10 @@ pub fn parse_binary(filename: &str, addr: u64, size: u64) -> Result<BinaryInfo, 
                 let name = elf.strtab[sym.st_name].to_string();
                 symbols.insert(name, sym.st_value + offset);
             }
+            for dynsym in elf.dynsyms.iter() {
+                let name = elf.dynstrtab[dynsym.st_name].to_string();
+                symbols.insert(name, dynsym.st_value + offset);
+            }
             Ok(BinaryInfo{filename: filename.to_owned(),
                           symbols,
                           bss_addr: bss_header.sh_addr + offset,


### PR DESCRIPTION
Some Linux distributions e.g. openSUSE deliver the python binary and
libpython with an empty ELF symtab. With this change py-spy also uses
the dynsym table for locating the relevant Python symbols.