### PR TITLE
Remoteprocess: rbspy amendments.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,14 +2,14 @@ use std::env;
 
 fn main() {
     // copied from remoteprocess/build.rs because I couldn't find a way to share this
+    // We only support native unwinding on x86_64 platforms
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64" {
+        return;
+    }
+
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
         "windows" => println!("cargo:rustc-cfg=unwind"),
-        "linux" => {
-            // We only support native unwinding on x86_64 linux
-            if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64"{
-                println!("cargo:rustc-cfg=unwind");
-            }
-        },
+        "linux" => println!("cargo:rustc-cfg=unwind"),
         _ => { }
     }
 }

--- a/remoteprocess/build.rs
+++ b/remoteprocess/build.rs
@@ -1,24 +1,26 @@
 use std::env;
 
 fn main() {
+    // We only support native unwinding on x86_64 platforms
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64" {
+        return;
+    }
+
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
         "windows" => println!("cargo:rustc-cfg=unwind"),
         "linux" => {
-            // We only support native unwinding on x86_64 linux
-            if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64"{
-                println!("cargo:rustc-cfg=unwind");
+            println!("cargo:rustc-cfg=unwind");
 
-                // statically link libunwind if compiling for musl, dynamically link otherwise
-                if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl" {
-                    println!("cargo:rustc-link-search=native=/usr/local/lib");
-                    println!("cargo:rustc-link-lib=static=unwind");
-                    println!("cargo:rustc-link-lib=static=unwind-ptrace");
-                    println!("cargo:rustc-link-lib=static=unwind-x86_64");
-                } else {
-                    println!("cargo:rustc-link-lib=dylib=unwind");
-                    println!("cargo:rustc-link-lib=dylib=unwind-ptrace");
-                    println!("cargo:rustc-link-lib=dylib=unwind-x86_64");
-                }
+            // statically link libunwind if compiling for musl, dynamically link otherwise
+            if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl" {
+                println!("cargo:rustc-link-search=native=/usr/local/lib");
+                println!("cargo:rustc-link-lib=static=unwind");
+                println!("cargo:rustc-link-lib=static=unwind-ptrace");
+                println!("cargo:rustc-link-lib=static=unwind-x86_64");
+            } else {
+                println!("cargo:rustc-link-lib=dylib=unwind");
+                println!("cargo:rustc-link-lib=dylib=unwind-ptrace");
+                println!("cargo:rustc-link-lib=dylib=unwind-x86_64");
             }
         },
         _ => { }

--- a/remoteprocess/src/lib.rs
+++ b/remoteprocess/src/lib.rs
@@ -226,6 +226,18 @@ pub trait ProcessMemory {
     fn copy_pointer<T>(&self, ptr: *const T) -> Result<T, Error> {
         self.copy_struct(ptr as usize)
     }
+
+    /// Copies a series of bytes from another process into a vector of
+    /// structures of type T.
+    fn copy_vec<T>(&self, addr: usize, length: usize)
+                       -> Result<Vec<T>, Error>
+    {
+        let mut vec = self.copy(addr, length * std::mem::size_of::<T>())?;
+        let capacity = vec.capacity() as usize / std::mem::size_of::<T>() as usize;
+        let ptr = vec.as_mut_ptr() as *mut T;
+        std::mem::forget(vec);
+        unsafe { Ok(Vec::from_raw_parts(ptr, capacity, capacity)) }
+    }
 }
 
 #[doc(hidden)]

--- a/remoteprocess/src/windows/mod.rs
+++ b/remoteprocess/src/windows/mod.rs
@@ -17,12 +17,16 @@ pub type Tid = Pid;
 
 use super::Error;
 
+#[cfg(unwind)]
 mod unwinder;
+#[cfg(unwind)]
 mod symbolication;
 mod syscalls_x64;
 
 use self::syscalls_x64::{Syscall, lookup_syscall};
+#[cfg(unwind)]
 pub use self::unwinder::Unwinder;
+#[cfg(unwind)]
 pub use self::symbolication::Symbolicator;
 
 pub struct Process {
@@ -166,10 +170,12 @@ impl Process {
         Ok(crate::filter_child_pids(self.pid, &processes))
     }
 
+    #[cfg(unwind)]
     pub fn unwinder(&self) -> Result<unwinder::Unwinder, Error> {
         unwinder::Unwinder::new(self.handle.0)
     }
 
+    #[cfg(unwind)]
     pub fn symbolicator(&self) -> Result<Symbolicator, Error> {
         Symbolicator::new(self.handle.0)
     }


### PR DESCRIPTION
Currently, rbspy implements a function which copies vector of arbitrary
structures of type U from remote process. Therefore, if we want rbspy
to leverage remoteprocess crate, we would need remoteprocess to
implement such function.

This change

* Implements `ProcessMemory#copy_vec` method, which copies a
  series of bytes from another process into a vector of structures of
  type T.
* Disables unwinding on non x86_64 platforms altogether, since build
  fails on 32-bit windows