### PR TITLE
Handle negative line increments in lnotab

### DIFF
--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -148,7 +148,13 @@ fn get_line_number<C: CodeObject, P: ProcessMemory>(code: &C, lasti: i32, proces
             break;
         }
 
-        line_number += i32::from(table[i + 1]);
+        let mut increment = i32::from(table[i + 1]);
+        // Handle negative line increments in the line number table - as shown here:
+        // https://github.com/python/cpython/blob/143a97f6/Objects/lnotab_notes.txt#L48-L49
+        if increment >= 0x80 {
+            increment -= -0x100;
+        }
+        line_number += increment;
         i += 2;
     }
 


### PR DESCRIPTION
Line number increments in the line number table can be negative occasionally,
and since we were loading as a table of u8 this wasn't being handled appropiately.
This might be causing issues like https://github.com/benfred/py-spy/issues/190

Change to match the logic in https://github.com/python/cpython/blob/143a97f6/Objects/lnotab_notes.txt#L48-L49