### PR TITLE
Make unwind code optional in remoteprocess

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.6"
-remoteprocess = {path="./remoteprocess", version="0.3.0"}
+remoteprocess = {path="./remoteprocess", version="0.3.0", features=["unwind"]}
 
 [target.'cfg(unix)'.dependencies]
 termios = "0.3.1"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,6 @@
 use std::env;
 
 fn main() {
-    // copied from remoteprocess/build.rs because I couldn't find a way to share this
-    // We only support native unwinding on x86_64 platforms
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64" {
         return;
     }

--- a/remoteprocess/Cargo.toml
+++ b/remoteprocess/Cargo.toml
@@ -34,3 +34,7 @@ winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handl
 
 [dev-dependencies]
 env_logger = "0.6.1"
+
+[features]
+default = []
+unwind = []

--- a/remoteprocess/build.rs
+++ b/remoteprocess/build.rs
@@ -7,20 +7,19 @@ fn main() {
     }
 
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
-        "windows" => println!("cargo:rustc-cfg=unwind"),
         "linux" => {
-            println!("cargo:rustc-cfg=unwind");
-
             // statically link libunwind if compiling for musl, dynamically link otherwise
-            if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl" {
-                println!("cargo:rustc-link-search=native=/usr/local/lib");
-                println!("cargo:rustc-link-lib=static=unwind");
-                println!("cargo:rustc-link-lib=static=unwind-ptrace");
-                println!("cargo:rustc-link-lib=static=unwind-x86_64");
-            } else {
-                println!("cargo:rustc-link-lib=dylib=unwind");
-                println!("cargo:rustc-link-lib=dylib=unwind-ptrace");
-                println!("cargo:rustc-link-lib=dylib=unwind-x86_64");
+            if env::var("CARGO_FEATURE_UNWIND").is_ok() {
+                if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl" {
+                    println!("cargo:rustc-link-search=native=/usr/local/lib");
+                    println!("cargo:rustc-link-lib=static=unwind");
+                    println!("cargo:rustc-link-lib=static=unwind-ptrace");
+                    println!("cargo:rustc-link-lib=static=unwind-x86_64");
+                } else {
+                    println!("cargo:rustc-link-lib=dylib=unwind");
+                    println!("cargo:rustc-link-lib=dylib=unwind-ptrace");
+                    println!("cargo:rustc-link-lib=dylib=unwind-x86_64");
+                }
             }
         },
         _ => { }

--- a/remoteprocess/examples/trace.rs
+++ b/remoteprocess/examples/trace.rs
@@ -4,7 +4,7 @@ extern crate goblin;
 #[cfg(target_os="linux")]
 extern crate nix;
 
-#[cfg(unwind)]
+#[cfg(feature="unwind")]
 fn get_backtrace(pid: remoteprocess::Pid) -> Result<(), remoteprocess::Error> {
     // Create a new handle to the process
     let process = remoteprocess::Process::new(pid)?;
@@ -35,7 +35,7 @@ fn get_backtrace(pid: remoteprocess::Pid) -> Result<(), remoteprocess::Error> {
     Ok(())
 }
 
-#[cfg(unwind)]
+#[cfg(feature="unwind")]
 fn main() {
     env_logger::init();
 
@@ -52,7 +52,7 @@ fn main() {
     }
 }
 
-#[cfg(not(unwind))]
+#[cfg(not(feature="unwind"))]]
 fn main() {
     panic!("unwind not supported!");
 }

--- a/remoteprocess/src/lib.rs
+++ b/remoteprocess/src/lib.rs
@@ -21,7 +21,7 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! #[cfg(unwind)]
+//! #[cfg(feature="unwind")]
 //! fn get_backtrace(pid: remoteprocess::Pid) -> Result<(), remoteprocess::Error> {
 //!     // Create a new handle to the process
 //!     let process = remoteprocess::Process::new(pid)?;
@@ -106,7 +106,7 @@ pub enum Error {
     GoblinError(::goblin::error::Error),
     IOError(std::io::Error),
     Other(String),
-    #[cfg(all(target_os="linux", unwind))]
+    #[cfg(all(target_os="linux", feature="unwind", target_arch="x86_64"))]
     LibunwindError(linux::libunwind::Error),
     #[cfg(target_os="linux")]
     NixError(nix::Error),
@@ -121,7 +121,7 @@ impl std::fmt::Display for Error {
             Error::GoblinError(ref e) => e.fmt(f),
             Error::IOError(ref e) => e.fmt(f),
             Error::Other(ref e) => write!(f, "{}", e),
-            #[cfg(all(target_os="linux", unwind))]
+            #[cfg(all(target_os="linux", feature="unwind", target_arch="x86_64"))]
             Error::LibunwindError(ref e) => e.fmt(f),
             #[cfg(target_os="linux")]
             Error::NixError(ref e) => e.fmt(f),
@@ -135,7 +135,7 @@ impl std::error::Error for Error {
             Error::NoBinaryForAddress(_) => "No binary found for address",
             Error::GoblinError(ref e) => e.description(),
             Error::IOError(ref e) => e.description(),
-            #[cfg(all(target_os="linux", unwind))]
+            #[cfg(all(target_os="linux", feature="unwind", target_arch="x86_64"))]
             Error::LibunwindError(ref e) => e.description(),
             #[cfg(target_os="linux")]
             Error::NixError(ref e) => e.description(),
@@ -147,7 +147,7 @@ impl std::error::Error for Error {
         match *self {
             Error::GoblinError(ref e) => Some(e),
             Error::IOError(ref e) => Some(e),
-            #[cfg(all(target_os="linux", unwind))]
+            #[cfg(all(target_os="linux", feature="unwind", target_arch="x86_64"))]
             Error::LibunwindError(ref e) => Some(e),
             #[cfg(target_os="linux")]
             Error::NixError(ref e) => Some(e),
@@ -175,7 +175,7 @@ impl From<nix::Error> for Error {
     }
 }
 
-#[cfg(all(target_os="linux", unwind))]
+#[cfg(all(target_os="linux", feature="unwind", target_arch="x86_64"))]
 impl From<linux::libunwind::Error> for Error {
     fn from(err: linux::libunwind::Error) -> Error {
         Error::LibunwindError(err)

--- a/remoteprocess/src/linux/mod.rs
+++ b/remoteprocess/src/linux/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(unwind)]
+#[cfg(all(feature="unwind", target_arch="x86_64"))]
 pub mod libunwind;
-#[cfg(unwind)]
+#[cfg(all(feature="unwind", target_arch="x86_64"))]
 mod symbolication;
 
 use libc::pid_t;
@@ -14,10 +14,10 @@ use std::fs::File;
 
 use super::Error;
 
-#[cfg(unwind)]
+#[cfg(all(feature="unwind", target_arch="x86_64"))]
 pub use self::symbolication::*;
 
-#[cfg(unwind)]
+#[cfg(all(feature="unwind", target_arch="x86_64"))]
 pub use self::libunwind::Unwinder;
 
 use read_process_memory::{CopyAddress, ProcessHandle};
@@ -109,12 +109,12 @@ impl Process {
         Ok(crate::filter_child_pids(self.pid, &processes))
     }
 
-    #[cfg(unwind)]
+    #[cfg(all(feature="unwind", target_arch="x86_64"))]
     pub fn unwinder(&self) -> Result<Unwinder, Error> {
         Ok(Unwinder::new()?)
     }
 
-    #[cfg(unwind)]
+    #[cfg(all(feature="unwind", target_arch="x86_64"))]
     pub fn symbolicator(&self) -> Result<Symbolicator, Error> {
         Ok(Symbolicator::new(self.pid)?)
     }

--- a/remoteprocess/src/windows/mod.rs
+++ b/remoteprocess/src/windows/mod.rs
@@ -17,16 +17,16 @@ pub type Tid = Pid;
 
 use super::Error;
 
-#[cfg(unwind)]
+#[cfg(feature="unwind")]
 mod unwinder;
-#[cfg(unwind)]
+#[cfg(feature="unwind")]
 mod symbolication;
 mod syscalls_x64;
 
 use self::syscalls_x64::{Syscall, lookup_syscall};
-#[cfg(unwind)]
+#[cfg(feature="unwind")]
 pub use self::unwinder::Unwinder;
-#[cfg(unwind)]
+#[cfg(feature="unwind")]
 pub use self::symbolication::Symbolicator;
 
 pub struct Process {
@@ -169,13 +169,11 @@ impl Process {
         }
         Ok(crate::filter_child_pids(self.pid, &processes))
     }
-
-    #[cfg(unwind)]
+    #[cfg(feature="unwind")]
     pub fn unwinder(&self) -> Result<unwinder::Unwinder, Error> {
         unwinder::Unwinder::new(self.handle.0)
     }
-
-    #[cfg(unwind)]
+    #[cfg(feature="unwind")]
     pub fn symbolicator(&self) -> Result<Symbolicator, Error> {
         Symbolicator::new(self.handle.0)
     }


### PR DESCRIPTION
Add an unwind feature in remoteprocess, so that the codee can be conditionally
compiled. py-spy needs this code, but rbspy doesn't and this code complicates
the build of remoteprocess.