### PR TITLE
Don't use setns for profiling docker containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
  "proc-maps 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "remoteprocess 0.3.0",
+ "remoteprocess 0.3.1",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "remoteprocess"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "addr2line 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "benfred-read-process-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -26,7 +26,11 @@ impl BinaryInfo {
 }
 
 /// Uses goblin to parse a binary file, returns information on symbols/bss/adjusted offset etc
-pub fn parse_binary(filename: &str, addr: u64, size: u64) -> Result<BinaryInfo, Error> {
+pub fn parse_binary(pid: remoteprocess::Pid, filename: &str, addr: u64, size: u64) -> Result<BinaryInfo, Error> {
+    // on linux the process could be running in docker, access the filename through procfs
+    #[cfg(target_os="linux")]
+    let filename = &format!("/proc/{}/root{}", pid, filename);
+
     let offset = addr;
 
     let mut symbols = HashMap::new();


### PR DESCRIPTION
setns can't handle multithreaded programs, and using it to profile programs
running in docker wasn't working with the recent subprocesses change. Instead
read files from /proc/PID/root as suggested here https://jvns.ca/blog/2018/01/26/spy-container/

https://github.com/benfred/py-spy/issues/199