### PR TITLE
Add support for speedscope profiles aggregated by function name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ impl Recorder for RawFlamegraph {
 fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error> {
     let mut output: Box<dyn Recorder> = match config.format {
         Some(FileFormat::flamegraph) => Box::new(flamegraph::Flamegraph::new(config.show_line_numbers)),
-        Some(FileFormat::speedscope) =>  Box::new(speedscope::Stats::new()),
+        Some(FileFormat::speedscope) =>  Box::new(speedscope::Stats::new(config.show_line_numbers)),
         Some(FileFormat::raw) => Box::new(RawFlamegraph(flamegraph::Flamegraph::new(config.show_line_numbers))),
         None => return Err(format_err!("A file format is required to record samples"))
     };


### PR DESCRIPTION
Previously all speedscope output included the line number, even if the user
generated the profile with the -F flag (Aggregate samples by function name
instead of by line number). Fix to not include line numbers in speedscope
profiles with the -F flag (#201)