### PR TITLE
Fix typo in handling of lnotab.

### DIFF
--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -152,7 +152,7 @@ fn get_line_number<C: CodeObject, P: ProcessMemory>(code: &C, lasti: i32, proces
         // Handle negative line increments in the line number table - as shown here:
         // https://github.com/python/cpython/blob/143a97f6/Objects/lnotab_notes.txt#L48-L49
         if increment >= 0x80 {
-            increment -= -0x100;
+            increment -= 0x100;
         }
         line_number += increment;
         i += 2;


### PR DESCRIPTION
Closes #190, AFAICT, by fixing a simple typo in #196.
(Perhaps it would be easier to just read increment as i8 and cast it to i32?  Dunno what's idiomatic rust, but that would at least look more idiomatic in C to me.)

Repro:
```
import time

def f():
    [time.sleep(.1)  # Must be split over two lines to see the error.
     for _ in range(10)]

f()
```