### PR TITLE
Add test for negative line number offests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     # then using to profile a 64bit pythhon issus?). Just test we can compile
     cargo build --verbose --target $TARGET
   else
-    cargo test --verbose --target $TARGET
+    travis_retry cargo test --verbose --target $TARGET
   fi
 
 # Adapted from rust-everwhere:

--- a/tests/scripts/negative_linenumber_offsets.py
+++ b/tests/scripts/negative_linenumber_offsets.py
@@ -1,0 +1,13 @@
+import time
+
+
+def f():
+    [
+        # Must be split over multiple lines to see the error.
+        # https://github.com/benfred/py-spy/pull/208
+        time.sleep(1)
+        for _ in range(1000)
+    ]
+
+
+f()


### PR DESCRIPTION
Under python 3.8 we were failing to accurately get line numbers because of
improper handling of negative line number offests in lnotab. Add a test
that verifies this as given in #208.