### PR TITLE
Fix dump --locals

### DIFF
--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -50,7 +50,7 @@ pub struct LocalVariable {
 }
 
 /// Given an InterpreterState, this function returns a vector of stack traces for each thread
-pub fn get_stack_traces<I>(interpreter: &I, process: &Process) -> Result<(Vec<StackTrace>), Error>
+pub fn get_stack_traces<I>(interpreter: &I, process: &Process) -> Result<Vec<StackTrace>, Error>
         where I: InterpreterState {
     // TODO: deprecate this method
     let mut ret = Vec::new();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -194,7 +194,7 @@ fn test_local_vars() {
     let frame = &trace.frames[0];
     let locals = frame.locals.as_ref().unwrap();
 
-    assert_eq!(locals.len(), 8);
+    assert_eq!(locals.len(), 9);
 
     let arg1 = &locals[0];
     assert_eq!(arg1.name, "arg1");
@@ -234,6 +234,10 @@ fn test_local_vars() {
     let local5 = &locals[7];
     assert_eq!(local5.name, "local5");
     assert!(!local5.arg);
+
+    let local6 = &locals[8];
+    assert_eq!(local6.name, "local6");
+    assert!(!local6.arg);
 
     // we only support dictionary lookup on python 3.6+ right now
     if runner.spy.version.major == 3 && runner.spy.version.minor >= 6 {

--- a/tests/scripts/local_vars.py
+++ b/tests/scripts/local_vars.py
@@ -7,7 +7,10 @@ def local_variable_lookup(arg1="foo", arg2=None, arg3=True):
     local3 = 123456789123456789
     local4 = 3.1415
     local5 = {"a": False, "b": (1, 2, 3)}
+    # https://github.com/benfred/py-spy/issues/224
+    local6 = ("-" * 115, {"key": {"key": {"key": "value"}}})
     time.sleep(100000)
+
 
 if __name__ == "__main__":
     local_variable_lookup()


### PR DESCRIPTION
The dump command could panic when trying to display local variables under
certain situations (nested variables in some contexts could cause the
max_length checking to come up with a negative value causing string
slicing to fail). Fix and add a unittest that would have caught this.