### PR TITLE
Fixes for not capturing output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,16 +405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goblin"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,7 +728,7 @@ dependencies = [
  "ctrlc 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inferno 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -750,7 +740,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_distr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "remoteprocess 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remoteprocess 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -848,12 +838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "remoteprocess"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "addr2line 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "benfred-read-process-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "libproc 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1222,7 +1212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gimli 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum goblin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
-"checksum goblin 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0259546d6aed5dd1f4efc3ae663cae62912ceb927c0e96ae1fc8a22ab1516763"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
@@ -1272,7 +1261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
-"checksum remoteprocess 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d14287e8e26452bbf674636db6930a34c1b2bab9d3eb9c124ef90b87495f3f29"
+"checksum remoteprocess 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "199b51a77d2cc9b36ef6419adf9984a8424a52aade25134c756f158c3ed84fbd"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rgb 0.8.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5ec4ab2cf0b27e111e266e161cf7f9efd20125a161190da1c0945c4a4408fef3"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ctrlc = "3"
 indicatif = "0.14"
 env_logger = "0.7"
 failure = "0.1.5"
-goblin = "0.2"
+goblin = "0.1.3"
 inferno = "0.9.1"
 lazy_static = "1.1.0"
 libc = "0.2.34"
@@ -33,7 +33,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.7"
 rand_distr = "0.2"
-remoteprocess = {version="0.3.3", features=["unwind"]}
+remoteprocess = {version="0.3.4", features=["unwind"]}
 
 [target.'cfg(unix)'.dependencies]
 termios = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ You can override this behaviour to use pip to install py-spy on Alpine by going:
 
 Alternatively you can download a musl binary from the [GitHub releases page](https://github.com/benfred/py-spy/releases).
 
-### How can you avoid pausing the Python program?
+### How can I avoid pausing the Python program?
 
 By setting the ```--nonblocking``` option, py-spy won't pause the target python you are profiling from. While
 the performance impact of sampling from a process with py-spy is usually extremely low, setting this option

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -245,6 +245,7 @@ fn test_local_vars() {
     }
 }
 
+#[cfg(not(target_os="freebsd"))]
 #[test]
 fn test_subprocesses() {
     #[cfg(target_os="macos")]
@@ -273,6 +274,7 @@ fn test_subprocesses() {
     }
 }
 
+#[cfg(not(target_os="freebsd"))]
 #[test]
 fn test_subprocesses_zombiechild() {
     #[cfg(target_os="macos")]


### PR DESCRIPTION
There were a couple issues with #222: this broke the duration
flag , and was hard to distinguish commandline output from py-spy
with commandline output from the application being profiled.
This fixes so the duration flag works again, and prefixes messages
showing that they are coming from py-spy.