### PR TITLE
Add parentheses around thread id to prevent diff flamegraph

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error>
 
             if config.include_thread_ids {
                 let threadid = trace.format_threadid();
-                trace.frames.push(Frame{name: format!("thread {}", threadid),
+                trace.frames.push(Frame{name: format!("thread ({})", threadid),
                     filename: String::from(""),
                     module: None, short_filename: None, line: 0, locals: None});
             }


### PR DESCRIPTION
The use of the --thread option can result in stack samples that look like `thread <thread_id> <count>`.  Inferno and Brendan Gregg's perl script will treat this as a function with name `thread` and two counts. This results in the creation of a [differential flamegraph](http://www.brendangregg.com/blog/2014-11-09/differential-flame-graphs.html) when not
desired. Changing the frame name to `thread (<thread_id>)` fixes this
issue. Note this is only an issue when there are no stack frames on top of the thread root (ie. `thread <thread_id>; A (file.py:123) <count>` is no problem). Below I've attached a zip with 4 profiles, 2 before the change and 2 after to demonstrate the issue. 


[example_files.zip](https://github.com/benfred/py-spy/files/4422386/example_files.zip)