### PR TITLE
Include python thread names in recording

### DIFF
--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,17 +1,11 @@
-use std::collections::HashMap;
-
 use console::style;
 use failure::Error;
 
 use crate::config::Config;
-use crate::python_bindings::{v3_6_6, v3_7_0, v3_8_0};
-use crate::python_interpreters::{InterpreterState, Object, TypeObject};
 use crate::python_spy::PythonSpy;
-use crate::python_data_access::{copy_string, copy_long, DictIterator};
+use crate::python_threading::thread_name_lookup;
 
-use crate::version::Version;
-
-use remoteprocess::{ProcessMemory, Pid};
+use remoteprocess::Pid;
 
 pub fn print_traces(pid: Pid, config: &Config) -> Result<(), Error> {
     let mut process = PythonSpy::new(pid, config)?;
@@ -21,15 +15,7 @@ pub fn print_traces(pid: Pid, config: &Config) -> Result<(), Error> {
         return Ok(())
     }
 
-    // try getting the threadnames, but don't sweat it if we can't. Since this relies on dictionary
-    // processing we only handle py3.6+ right now, and this doesn't work at all if the
-    // threading module isn't imported in the target program
-    let thread_names = match process.version {
-        Version{major: 3, minor: 6, ..} => thread_name_lookup::<v3_6_6::_is>(&process).ok(),
-        Version{major: 3, minor: 7, ..} => thread_name_lookup::<v3_7_0::_is>(&process).ok(),
-        Version{major: 3, minor: 8, ..} => thread_name_lookup::<v3_8_0::_is>(&process).ok(),
-        _ => None
-    };
+    let thread_names = thread_name_lookup(&process);
 
     println!("Process {}: {}",
         style(process.pid).bold().yellow(),
@@ -83,48 +69,4 @@ pub fn print_traces(pid: Pid, config: &Config) -> Result<(), Error> {
         }
     }
     Ok(())
-}
-
-/// Returns a hashmap of threadid: threadname, by inspecting the '_active' variable in the
-/// 'threading' module.
-fn thread_name_lookup<I: InterpreterState>(spy: &PythonSpy) -> Result<HashMap<u64, String>, Error> {
-    let mut ret = HashMap::new();
-    let process = &spy.process;
-    let interp: I = process.copy_struct(spy.interpreter_address)?;
-    for entry in DictIterator::from(process, interp.modules() as usize)? {
-        let (key, value) = entry?;
-        let module_name = copy_string(key as *const I::StringObject, process)?;
-        if module_name == "threading" {
-            let module: I::Object = process.copy_struct(value)?;
-            let module_type = process.copy_pointer(module.ob_type())?;
-            let dictptr: usize = process.copy_struct(value + module_type.dictoffset() as usize)?;
-            for i in DictIterator::from(process, dictptr)? {
-                let (key, value) = i?;
-                let name = copy_string(key as *const I::StringObject, process)?;
-                if name == "_active" {
-                    for i in DictIterator::from(process, value)? {
-                        let (key, value) = i?;
-                        let (threadid, _) = copy_long(process, key)?;
-
-                        let thread: I::Object = process.copy_struct(value)?;
-                        let thread_type = process.copy_pointer(thread.ob_type())?;
-                        let thread_dict_addr: usize = process.copy_struct(value + thread_type.dictoffset() as usize)?;
-
-                        for i in DictIterator::from(process, thread_dict_addr)? {
-                            let (key, value) = i?;
-                            let varname = copy_string(key as *const I::StringObject, process)?;
-                            if varname == "_name" {
-                                let threadname = copy_string(value as *const I::StringObject, process)?;
-                                ret.insert(threadid as u64, threadname);
-                                break;
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-            break;
-        }
-    }
-    Ok(ret)
 }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -3,7 +3,6 @@ use failure::Error;
 
 use crate::config::Config;
 use crate::python_spy::PythonSpy;
-use crate::python_threading::thread_name_lookup;
 
 use remoteprocess::Pid;
 
@@ -14,8 +13,6 @@ pub fn print_traces(pid: Pid, config: &Config) -> Result<(), Error> {
         println!("{}", serde_json::to_string_pretty(&traces)?);
         return Ok(())
     }
-
-    let thread_names = thread_name_lookup(&process);
 
     println!("Process {}: {}",
         style(process.pid).bold().yellow(),
@@ -29,11 +26,7 @@ pub fn print_traces(pid: Pid, config: &Config) -> Result<(), Error> {
 
     for trace in traces.iter().rev() {
         let thread_id = trace.format_threadid();
-        let thread_name = match thread_names.as_ref() {
-            Some(names) => names.get(&trace.thread_id),
-            None => None
-        };
-        match thread_name {
+        match trace.thread_name.as_ref() {
             Some(name) => {
                 println!("Thread {} ({}): \"{}\"", style(thread_id).bold().yellow(), trace.status_str(), name);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ mod python_bindings;
 mod python_interpreters;
 mod python_spy;
 mod python_data_access;
+mod python_threading;
 pub mod sampler;
 mod stack_trace;
 pub mod timer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod python_bindings;
 mod python_interpreters;
 mod python_spy;
 mod python_data_access;
+mod python_threading;
 mod stack_trace;
 mod console_viewer;
 mod flamegraph;

--- a/src/python_threading.rs
+++ b/src/python_threading.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use failure::Error;
+
+use crate::python_bindings::{v3_6_6, v3_7_0, v3_8_0};
+use crate::python_interpreters::{InterpreterState, Object, TypeObject};
+use crate::python_spy::PythonSpy;
+use crate::python_data_access::{copy_string, copy_long, DictIterator};
+
+use crate::version::Version;
+
+use remoteprocess::ProcessMemory;
+
+/// Returns a hashmap of threadid: threadname, by inspecting the '_active' variable in the
+/// 'threading' module.
+fn _thread_name_lookup<I: InterpreterState>(spy: &PythonSpy) -> Result<HashMap<u64, String>, Error> {
+    let mut ret = HashMap::new();
+    let process = &spy.process;
+    let interp: I = process.copy_struct(spy.interpreter_address)?;
+    for entry in DictIterator::from(process, interp.modules() as usize)? {
+        let (key, value) = entry?;
+        let module_name = copy_string(key as *const I::StringObject, process)?;
+        if module_name == "threading" {
+            let module: I::Object = process.copy_struct(value)?;
+            let module_type = process.copy_pointer(module.ob_type())?;
+            let dictptr: usize = process.copy_struct(value + module_type.dictoffset() as usize)?;
+            for i in DictIterator::from(process, dictptr)? {
+                let (key, value) = i?;
+                let name = copy_string(key as *const I::StringObject, process)?;
+                if name == "_active" {
+                    for i in DictIterator::from(process, value)? {
+                        let (key, value) = i?;
+                        let (threadid, _) = copy_long(process, key)?;
+
+                        let thread: I::Object = process.copy_struct(value)?;
+                        let thread_type = process.copy_pointer(thread.ob_type())?;
+                        let thread_dict_addr: usize = process.copy_struct(value + thread_type.dictoffset() as usize)?;
+
+                        for i in DictIterator::from(process, thread_dict_addr)? {
+                            let (key, value) = i?;
+                            let varname = copy_string(key as *const I::StringObject, process)?;
+                            if varname == "_name" {
+                                let threadname = copy_string(value as *const I::StringObject, process)?;
+                                ret.insert(threadid as u64, threadname);
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            break;
+        }
+    }
+    Ok(ret)
+}
+
+// try getting the threadnames, but don't sweat it if we can't. Since this relies on dictionary
+// processing we only handle py3.6+ right now, and this doesn't work at all if the
+// threading module isn't imported in the target program
+pub fn thread_name_lookup(process: &PythonSpy) -> Option<HashMap<u64, String>> {
+    match process.version {
+        Version{major: 3, minor: 6, ..} => _thread_name_lookup::<v3_6_6::_is>(&process).ok(),
+        Version{major: 3, minor: 7, ..} => _thread_name_lookup::<v3_7_0::_is>(&process).ok(),
+        Version{major: 3, minor: 8, ..} => _thread_name_lookup::<v3_8_0::_is>(&process).ok(),
+        _ => None
+    }
+}

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -14,6 +14,8 @@ pub struct StackTrace {
     pub pid: Pid,
     /// The python thread id for this stack trace
     pub thread_id: u64,
+    // The python thread name for this stack trace
+    pub thread_name: Option<String>,
     /// The OS thread id for this stack tracee
     pub os_thread_id: Option<u64>,
     /// Whether or not the thread was active
@@ -106,7 +108,7 @@ pub fn get_stack_trace<T>(thread: &T, process: &Process, copy_locals: bool) -> R
         frame_ptr = frame.back();
     }
 
-    Ok(StackTrace{pid: process.pid, frames, thread_id: thread.thread_id(), owns_gil: false, active: true, os_thread_id: None})
+    Ok(StackTrace{pid: process.pid, frames, thread_id: thread.thread_id(), thread_name: None, owns_gil: false, active: true, os_thread_id: None})
 }
 
 impl StackTrace {

--- a/tests/scripts/thread_names.py
+++ b/tests/scripts/thread_names.py
@@ -1,0 +1,13 @@
+import time
+import threading
+
+
+def main():
+    for i in range(10):
+        th = threading.Thread(target = lambda: time.sleep(10000))
+        th.name = "CustomThreadName-%s" % i
+        th.start()
+    time.sleep(10000)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In comparison to single py-spy dump, a recording doesn't include the custom defined python thread name. While analysing the performance of an application with various threads, I spent the most time on identifying the thread so that I could correlate the recording with other observability data e.g. logs and distributed traces.

This change extends py-spy's recording capabilities by including the python thread name in each stacktrace struct. The speedscope output formatter uses the collected data to create sample profiles with the thread name as profile name so that the thread name is visible in the speedscope UI.