### PR TITLE
Attempt to fix FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-0-release-amd64
+  image_family: freebsd-12-1
 
 freebsd_task:
   name: $TOOLCHAIN x86_64-unknown-freebsd


### PR DESCRIPTION
FreeBSD builds have been failing on cirrus with a message like "pkg: repository
meta /var/db/pkg/FreeBSD.meta has wrong version 2". Try to fix by using
the image_family parameters listed in the cirrus docs
(https://cirrus-ci.org/guide/FreeBSD/)