### PR TITLE
Add AlreadyLocked locking strategy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@ extern crate rand;
 extern crate rand_distr;
 extern crate remoteprocess;
 
-mod config;
-mod binary_parser;
+pub mod config;
+pub mod binary_parser;
 #[cfg(unwind)]
 mod cython;
 #[cfg(unwind)]

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -35,7 +35,7 @@ impl NativeStack {
                               python,
                               libpython,
                               process,
-                              symbol_cache: LruCache::new(4096)
+                              symbol_cache: LruCache::new(65536)
                               });
     }
 


### PR DESCRIPTION
We already had code to sample with or without locking the target process,
but disabling locking also disabled some other functionality like
native tracing and looking up OS thread ids. For use as a library, its
helpful to have a 3rd option which indicates that the process is already
locked - so we shouldn't attempt to lock it, but can try to get native
traces and the OS thread id.