### PR TITLE
Fix subprocess sampling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = "3.0.3"
 proc-maps = "0.1.6"
 memmap = "0.7.0"
 cpp_demangle = "0.3.0"
-serde = "1.0"
+serde = {version="1.0", features=["rc"]}
 serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.7"

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,10 +60,10 @@ arg_enum!{
     }
 }
 
-
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum LockingStrategy {
     NonBlocking,
+    #[allow(dead_code)]
     AlreadyLocked,
     Lock
 }

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -247,7 +247,8 @@ impl PythonSpy {
             {
                 if self.config.native {
                     if let Some(native) = self.native.as_mut() {
-                        let os_thread = remoteprocess::Thread::new(os_thread_id.unwrap())?;
+                        let thread_id = os_thread_id.ok_or_else(|| format_err!("failed to get os threadid"))?;
+                        let os_thread = remoteprocess::Thread::new(thread_id)?;
                         trace.frames = native.merge_native_thread(&trace.frames, &os_thread)?
                     }
                 }


### PR DESCRIPTION
In certain cases subprocess sampling was failing. This was related to the process
info map we were sending back with the samples. When a process exitted we
cleaned up the information about the process from the map, but in another thread
was accessing to display the process hierarchy.

Fix by not returning the process info map to the caller, and instead return a
linked list of process information (that is immutable and ref counted) with
each sample.