### PR TITLE
Add support for native extensions on ARM (for linux)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,12 @@
 use std::env;
 
 fn main() {
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64" {
-        return;
-    }
-
-    match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
-        "windows" => println!("cargo:rustc-cfg=unwind"),
-        "linux" => println!("cargo:rustc-cfg=unwind"),
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    match (target_arch.as_ref(), target_os.as_ref())  {
+        ("x86_64", "windows") |
+        ("x86_64", "linux") |
+        ("arm", "linux")  =>  println!("cargo:rustc-cfg=unwind"),
         _ => { }
     }
 }

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -409,12 +409,16 @@ impl PythonSpy {
 
         let mut cursor = unwinder.cursor(thread)?;
         while let Some(_) = cursor.next() {
-            // the pthread_id is usually in the top-level frame of the thread, but on some configs
-            // can be 2nd level. Handle this by taking the top-most rbx value that is one of the
-            // pthread_ids we're looking for
-            if let Ok(bx) = cursor.bx() {
-                if bx != 0 && threadids.contains(&bx) {
-                    pthread_id = bx;
+            // the pthread_id is usually a register (rbx on x86-64, r5 on ARM) in the top-level
+            // frame of the thread, but on some configs can be 2nd level. Handle this by taking the
+            // top-most value that is one of the pthread_ids we're looking for
+            #[cfg(target_arch="x86_64")]
+            let possible_threadid = cursor.bx();
+            #[cfg(target_arch="arm")]
+            let possible_threadid = cursor.r5();
+            if let Ok(reg) = possible_threadid {
+                if reg != 0 && threadids.contains(&reg) {
+                    pthread_id = reg;
                 }
             }
         }


### PR DESCRIPTION
This takes a similar approach to the x86-64 support for native extensions:

- unwind the stack using libunwind
- look-up the pthread ID from registers in early stack frames

The first of these is relatively simple (benfred/remoteprocess#5), and the
second is answerable in a basic form, using a debugger: on my machine
(see below for details), the pthread ID ended up in registers r5 and r9
in one of the initial stack frames.

Machine details:

- Raspberry Pi 4B
- kernel: 5.4.72-v7l+
- glibc: `GNU C Library (Debian GLIBC 2.28-10+rpi1) stable release version 2.28.`

Fixes #327

---

As an example, the following `test2.py` program just does some operations using Numpy and its native extensions:

```python
import numpy as np


def foo():
    data = np.random.gamma(2, 3, size=10000000)
    data.sort()
    print(data.mean())


def bar():
    foo()


def baz():
    foo()
    bar()


baz()
```

The following two traces compare the `--native` vs. not flamegraphs. The `--native` one is clearly more detailed and informative, showing the internals of the Numpy calls.

`py-spy record --native --output test2.svg python ./test2.py`

![image](https://user-images.githubusercontent.com/1203825/101999968-3a441200-3d36-11eb-8258-cfe3b13ccb8e.png)

`py-spy record --output test2-no-native.svg python ./test2.py`

![image](https://user-images.githubusercontent.com/1203825/101999979-55168680-3d36-11eb-84e5-e4a68fbf0231.png)

---

For testing, one approach might be https://github.com/rust-embedded/cross/ on CI.