### PR TITLE
Set default macOS deployment target to 10.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 
 from setuptools import setup
 from setuptools.command.install import install
@@ -28,6 +29,9 @@ try:
                 plat = "manylinux1_i686"
             elif cross_compile_target == "x86_64-unknown-linux-musl":
                 plat = "manylinux1_x86_64"
+            elif platform.system() == "Darwin" and os.getenv('MACOSX_DEPLOYMENT_TARGET'):
+                target = os.environ['MACOSX_DEPLOYMENT_TARGET']
+                plat = "macosx_{}_{}".format(target.replace(".", "_"), platform.machine())
 
             python, abi = "py2.py3", "none"
             return python, abi, plat
@@ -65,6 +69,9 @@ class PostInstallCommand(install):
         else:
             compile_args = ""
             build_dir = os.path.join(source_dir, "target", "release")
+
+        if platform.system() == "Darwin":
+            os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
 
         # setuptools_rust doesn't seem to let me specify a musl cross compilation target
         # so instead just build ourselves here =(.


### PR DESCRIPTION
Currently the platform tag of the  wheel built by GitHub Actions for macOS is `macosx_10_14_x86_64` as shown in https://pypi.org/project/py-spy/#files

Since it's distributing a Rust binary, we can set `MACOSX_DEPLOYMENT_TARGET` to a lower version so that the wheel can be installed on lower version macOS system. I'm choosing 10.9 because numpy/scipy also uses 10.9.

Note that when running `python setup.py bdist_wheel` it will print a warning

```
[WARNING] MACOSX_DEPLOYMENT_TARGET is set to a lower value (10.9) than the version on which the Python interpreter was compiled (10.14), and will be ignored.
```

It can be ignored since it does not distributing any Python native extensions. To remove the warning we have to use a Python interpreter compiled with macOS 10.9 SDK, but there isn't any on GitHub Actions: https://github.com/actions/setup-python/issues/26. 

The best we can do is to use miniconda but that's just annoying. (I do have an example using miniconda here: https://github.com/messense/fasttext-wheel/pull/1/files)