### PR TITLE
Detect GIL on 3.8.8

### DIFF
--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -88,7 +88,7 @@ pub mod pyruntime {
                     _  => Some(788)
                 }
             },
-            Version{major: 3, minor: 8, patch: 1..=7, ..} => Some(788),
+            Version{major: 3, minor: 8, patch: 1..=8, ..} => Some(788),
             Version{major: 3, minor: 9, patch: 0..=1, ..} => Some(352),
             _ => None
         }
@@ -128,7 +128,7 @@ pub mod pyruntime {
                     _  => Some(1368)
                 }
              },
-            Version{major: 3, minor: 8, patch: 1..=7, ..} => Some(1368),
+            Version{major: 3, minor: 8, patch: 1..=8, ..} => Some(1368),
             Version{major: 3, minor: 9, patch: 0..=1, ..} => Some(568),
             _ => None
         }


### PR DESCRIPTION
I actually expected it to have some real diff :shrug:

Used `generate_bindings.py`, once with `gcc` and once with `gcc -m32` to verify `target_os="linux", target_arch="x86"`. Don't have access to other archs to test them, sadly.

Closes: #357 (tested after this branch, GIL detection works fine now)