### PR TITLE
Exit with an error if --gil but we failed to get necessary addrs/offsets

### DIFF
--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -51,6 +51,7 @@ fn exit_if_gil(config: &Config, version: &Version, msg: &str) {
         eprintln!("Please open an issue in https://github.com/benfred/py-spy with the Python version and your platform.");
         std::process::exit(1);
     }
+    warn!("Unable to detect GIL usage: {}", msg);
 }
 
 impl PythonSpy {


### PR DESCRIPTION
Previously we'd just emit a warning, which is less noticeable; and the result of
a --gil run where without the needed information is going to empty, anyway.

I think it's better, user-experience wise (like mentioned in https://github.com/benfred/py-spy/pull/358#issuecomment-798978091). Well at least I can vouch for it personally, I'm quite annoyed by `--gil` recordings producing empty stack files / graphs, it always takes me a short while to recall the possibility that it is simply unsupported...

About the positioning of the check - might've been nicer to place this code in `main.rs`, but it's much easier if the exit decision is made next to the failure itself. I can try moving it if you think that's better.