### PR TITLE
Detect GIL on 3.9.2

### DIFF
--- a/generate_bindings.py
+++ b/generate_bindings.py
@@ -15,7 +15,7 @@ import tempfile
 def build_python(cpython_path, version):
     # TODO: probably easier to use pyenv for this?
     print("Compiling python %s from repo at %s" % (version, cpython_path))
-    install_path = os.path.join(cpython_path, version)
+    install_path = os.path.abspath(os.path.join(cpython_path, version))
 
     ret = os.system(f"""
         cd {cpython_path}
@@ -42,7 +42,7 @@ def calculate_pyruntime_offsets(cpython_path, version, configure=False):
         return ret
 
     if configure:
-        os.system(f"cd {cpython_path} && ./configure prefix=" + os.path.join(cpython_path, version))
+        os.system(f"cd {cpython_path} && ./configure prefix=" + os.path.abspath(os.path.join(cpython_path, version)))
 
     # simple little c program to get the offsets we need from the pyruntime struct
     # (using rust bindgen here is more complicated than necessary)
@@ -105,7 +105,7 @@ def extract_bindings(cpython_path, version, configure=False):
         git checkout {version}
 
         # need to run configure on the current branch to generate pyconfig.h sometimes
-        {("./configure prefix=" + os.path.join(cpython_path, version)) if configure else ""}
+        {("./configure prefix=" + os.path.abspath(os.path.join(cpython_path, version))) if configure else ""}
 
         cat Include/Python.h > bindgen_input.h
         cat Include/frameobject.h >> bindgen_input.h

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -89,7 +89,7 @@ pub mod pyruntime {
                 }
             },
             Version{major: 3, minor: 8, patch: 1..=8, ..} => Some(788),
-            Version{major: 3, minor: 9, patch: 0..=1, ..} => Some(352),
+            Version{major: 3, minor: 9, patch: 0..=2, ..} => Some(352),
             _ => None
         }
     }
@@ -129,7 +129,7 @@ pub mod pyruntime {
                 }
              },
             Version{major: 3, minor: 8, patch: 1..=8, ..} => Some(1368),
-            Version{major: 3, minor: 9, patch: 0..=1, ..} => Some(568),
+            Version{major: 3, minor: 9, patch: 0..=2, ..} => Some(568),
             _ => None
         }
     }


### PR DESCRIPTION
Again, took me a while to realize this is the problem :sweat_smile:  https://github.com/benfred/py-spy/pull/361 would have helped.

Tested on Linux x86-64 & x86 (building with `-m32`)