### PR TITLE
Use /proc/pid/exe for the Python binary in Linux

### DIFF
--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -32,9 +32,9 @@ pub fn parse_binary(_pid: remoteprocess::Pid, filename: &str, addr: u64, size: u
     // across namespaces just like /proc/pid/root, and also if the file was deleted.
     #[cfg(target_os="linux")]
     let filename = &if _is_bin {
-        format!("/proc/{}/exe", _pid);
+        format!("/proc/{}/exe", _pid)
     } else {
-        format!("/proc/{}/root{}", _pid, filename);
+        format!("/proc/{}/root{}", _pid, filename)
     };
 
     let offset = addr;

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -31,14 +31,10 @@ pub fn parse_binary(_pid: remoteprocess::Pid, filename: &str, addr: u64, size: u
     // if filename is the binary executable (not libpython) - take it from /proc/pid/exe, which works
     // across namespaces just like /proc/pid/root, and also if the file was deleted.
     #[cfg(target_os="linux")]
-    let _tmp;
-    #[cfg(target_os="linux")]
-    let filename = if _is_bin {
-        _tmp = format!("/proc/{}/exe", _pid);
-        &_tmp
+    let filename = &if _is_bin {
+        format!("/proc/{}/exe", _pid);
     } else {
-        _tmp = format!("/proc/{}/root{}", _pid, filename);
-        &_tmp
+        format!("/proc/{}/root{}", _pid, filename);
     };
 
     let offset = addr;

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -738,7 +738,7 @@ impl PythonProcessInfo {
 
             // TODO: consistent types? u64 -> usize? for map.start etc
             #[allow(unused_mut)]
-            let python_binary = parse_binary(process.pid, &filename, map.start() as u64, map.size() as u64)
+            let python_binary = parse_binary(process.pid, &filename, map.start() as u64, map.size() as u64, true)
                 .and_then(|mut pb| {
                     // windows symbols are stored in separate files (.pdb), load
                     #[cfg(windows)]
@@ -783,7 +783,7 @@ impl PythonProcessInfo {
                 if let Some(filename) = &libpython.filename() {
                     info!("Found libpython binary @ {}", filename);
                     #[allow(unused_mut)]
-                    let mut parsed = parse_binary(process.pid, filename, libpython.start() as u64, libpython.size() as u64)?;
+                    let mut parsed = parse_binary(process.pid, filename, libpython.start() as u64, libpython.size() as u64, false)?;
                     #[cfg(windows)]
                     parsed.symbols.extend(get_windows_python_symbols(process.pid, filename, libpython.start() as u64)?);
                     libpython_binary = Some(parsed);
@@ -813,7 +813,7 @@ impl PythonProcessInfo {
                     if let Some(libpython) = python_dyld_data {
                         info!("Found libpython binary from dyld @ {}", libpython.filename);
 
-                        let mut binary = parse_binary(process.pid, &libpython.filename, libpython.segment.vmaddr, libpython.segment.vmsize)?;
+                        let mut binary = parse_binary(process.pid, &libpython.filename, libpython.segment.vmaddr, libpython.segment.vmsize, false)?;
 
                         // TODO: bss addr offsets returned from parsing binary are wrong
                         // (assumes data section isn't split from text section like done here).


### PR DESCRIPTION
Instead of "/proc/pid/root/$(readlink /proc/pid/exe)", we'll just use /proc/pid/exe
which provides access to the file even if it was deleted on-disk.

This is not uncommon - for example, Python may be upgraded and thus long-running
processes no longer have the correct file at the specified path.
After this change we can profile/dump those processes (only if they are Python-binary
based and not libpython-based; the latter is inaccessible if deleted... perhaps only
partially accessible via /proc/pid/map_files).

Note: this depends on https://github.com/rbspy/proc-maps/pull/8 because currently we don't extract the full filename from `/proc/pid/maps`, so the comparison in `is_python_bin` (matching `readlink("/proc/pid/exe")` to filenames in `/proc/pid/maps`) always fails.

With this PR (and the `proc-maps` fix) I managed to `py-spy dump` Python processes that were started before I upgraded Python on my local box :) (so they now run `/usr/bin/python3.8 (deleted)`)