### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,20 @@ build="build.rs"
 
 [dependencies]
 clap = {version="2", features=["wrap_help"]}
-console = "0.13"
+console = "0.14"
 ctrlc = "3"
 indicatif = "0.15"
 env_logger = "0.8"
 failure = "0.1.8"
-goblin = "0.2.3"
-inferno = "0.10.2"
+goblin = "0.3"
+inferno = "0.10.3"
 lazy_static = "1.1.0"
 libc = "0.2.82"
 log = "0.4"
 lru = "0.6"
 regex = "1"
 tempfile = "3.0.3"
-proc-maps = "0.1.6"
+proc-maps = "0.1.7"
 memmap = "0.7.0"
 cpp_demangle = "0.3.2"
 serde = {version="1.0", features=["rc"]}
@@ -33,7 +33,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.8"
 rand_distr = "0.4"
-remoteprocess = {version="0.4.2", features=["unwind"]}
+remoteprocess = {version="0.4.3", features=["unwind"]}
 chrono = "0.4.19"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Include the lates fixes from proc-maps/read-process-memory/remoteprocess