### PR TITLE
Detect GIL on 3.9.3, 3.9.4, 3.8.9

### DIFF
--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -88,8 +88,8 @@ pub mod pyruntime {
                     _  => Some(788)
                 }
             },
-            Version{major: 3, minor: 8, patch: 1..=8, ..} => Some(788),
-            Version{major: 3, minor: 9, patch: 0..=2, ..} => Some(352),
+            Version{major: 3, minor: 8, patch: 1..=9, ..} => Some(788),
+            Version{major: 3, minor: 9, patch: 0..=4, ..} => Some(352),
             _ => None
         }
     }
@@ -128,8 +128,8 @@ pub mod pyruntime {
                     _  => Some(1368)
                 }
              },
-            Version{major: 3, minor: 8, patch: 1..=8, ..} => Some(1368),
-            Version{major: 3, minor: 9, patch: 0..=2, ..} => Some(568),
+            Version{major: 3, minor: 8, patch: 1..=9, ..} => Some(1368),
+            Version{major: 3, minor: 9, patch: 0..=4, ..} => Some(568),
             _ => None
         }
     }


### PR DESCRIPTION
Tested `py-spy record --gil` on the following Docker images: `python:3.9.3`, `python:3.9.4`, `python:3.8.9` - works now, hasn't worked before.