### PR TITLE
Tweak subprocess retry logic

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -382,10 +382,8 @@ fn test_delayed_subprocess() {
     let config = Config{subprocesses: true, ..Default::default()};
     let sampler = py_spy::sampler::Sampler::new(process.id(), &config).unwrap();
     for sample in sampler {
-        // wait for other processes here if we don't have the expected number
-        let traces = sample.traces;
-
         // should have one trace from the subprocess
+        let traces = sample.traces;
         assert_eq!(traces.len(), 1);
         assert!(traces[0].pid != process.id());
         break;

--- a/tests/scripts/delayed_launch.sh
+++ b/tests/scripts/delayed_launch.sh
@@ -1,0 +1,2 @@
+sleep 0.5
+python -c "import time; time.sleep(1000)"


### PR DESCRIPTION
Change subprocess retry logic to handle the case where the main process is a python
process and no children processes have been created yet. Also add a basic integration
test for the case where python subprocesses are delayed in starting (from a non-python
root process).