### PR TITLE
For python 3.8/3.9 don't consider patch for GIL offsets

### DIFF
--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -70,8 +70,8 @@ pub mod pyruntime {
                     _ => Some(1416),
                 }
              },
-             Version{major: 3, minor: 8, patch: 1..=9, ..} => { Some(1416) },
-             Version{major: 3, minor: 9, patch: 0..=4, ..} => { Some(616) },
+             Version{major: 3, minor: 8, ..} => { Some(1416) },
+             Version{major: 3, minor: 9, ..} => { Some(616) },
              _ => None
         }
     }
@@ -88,8 +88,8 @@ pub mod pyruntime {
                     _  => Some(788)
                 }
             },
-            Version{major: 3, minor: 8, patch: 1..=9, ..} => Some(788),
-            Version{major: 3, minor: 9, patch: 0..=4, ..} => Some(352),
+            Version{major: 3, minor: 8, ..} => Some(788),
+            Version{major: 3, minor: 9, ..} => Some(352),
             _ => None
         }
     }
@@ -128,8 +128,8 @@ pub mod pyruntime {
                     _  => Some(1368)
                 }
              },
-            Version{major: 3, minor: 8, patch: 1..=9, ..} => Some(1368),
-            Version{major: 3, minor: 9, patch: 0..=4, ..} => Some(568),
+            Version{major: 3, minor: 8, ..} => Some(1368),
+            Version{major: 3, minor: 9, ..} => Some(568),
             _ => None
         }
     }
@@ -151,8 +151,8 @@ pub mod pyruntime {
                     _ => Some(1296)
                 }
             },
-            Version{major: 3, minor: 8, patch: 1..=9, ..} => Some(1296),
-            Version{major: 3, minor: 9, patch: 0..=4, ..} => Some(496),
+            Version{major: 3, minor: 8, ..} => Some(1296),
+            Version{major: 3, minor: 9, ..} => Some(496),
             _ => None
         }
     }
@@ -170,8 +170,8 @@ pub mod pyruntime {
                     _ => Some(1224)
                 }
             },
-            Version{major: 3, minor: 8, patch: 1..=9, ..} => Some(1224),
-            Version{major: 3, minor: 9, patch: 0..=4, ..} => Some(424),
+            Version{major: 3, minor: 8, ..} => Some(1224),
+            Version{major: 3, minor: 9, ..} => Some(424),
             _ => None
         }
     }


### PR DESCRIPTION
We're relying on automatically testing each patch version, so we don't need
to manually add the GIL offsets for every patch release.