### PR TITLE
Fix thread names on armv7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,12 +128,12 @@ jobs:
         continue-on-error: true
       - name: Test macOS Wheel (Retry#1)
         id: osx_test1
-        run: python tests/integration_test.py
+        run: sudo "PATH=$PATH" python tests/integration_test.py
         if: steps.osx_test.outcome=='failure'
         continue-on-error: true
       - name: Test macOS Wheel (Retry#2)
         id: osx_test2
-        run: python tests/integration_test.py
+        run: sudo "PATH=$PATH" python tests/integration_test.py
         if: steps.osx_test1.outcome=='failure'
 
   test-wheel-linux-armv7:

--- a/src/python_bindings/v3_6_6.rs
+++ b/src/python_bindings/v3_6_6.rs
@@ -658,7 +658,10 @@ impl Default for PyUnicodeObject {
     }
 }
 pub type PyLongObject = _longobject;
+#[cfg(target_pointer_width = "64")]
 pub type digit = u32;
+#[cfg(target_pointer_width = "32")]
+pub type digit = u16;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _longobject {

--- a/src/python_bindings/v3_7_0.rs
+++ b/src/python_bindings/v3_7_0.rs
@@ -696,7 +696,10 @@ impl Default for PyUnicodeObject {
     }
 }
 pub type PyLongObject = _longobject;
+#[cfg(target_pointer_width = "64")]
 pub type digit = u32;
+#[cfg(target_pointer_width = "32")]
+pub type digit = u16;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _longobject {

--- a/src/python_bindings/v3_8_0.rs
+++ b/src/python_bindings/v3_8_0.rs
@@ -705,7 +705,10 @@ impl Default for PyUnicodeObject {
     }
 }
 pub type PyLongObject = _longobject;
+#[cfg(target_pointer_width = "64")]
 pub type digit = u32;
+#[cfg(target_pointer_width = "32")]
+pub type digit = u16;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _longobject {

--- a/src/python_bindings/v3_9_5.rs
+++ b/src/python_bindings/v3_9_5.rs
@@ -742,7 +742,10 @@ impl Default for PyUnicodeObject {
     }
 }
 pub type PyLongObject = _longobject;
+#[cfg(target_pointer_width = "64")]
 pub type digit = u32;
+#[cfg(target_pointer_width = "32")]
+pub type digit = u16;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _longobject {

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -42,7 +42,7 @@ impl Sampler {
         thread::spawn(move || {
             // We need to create this object inside the thread here since PythonSpy objects don't
             // have the Send trait implemented on linux
-            let mut spy = match PythonSpy::retry_new(pid, &config, 5) {
+            let mut spy = match PythonSpy::retry_new(pid, &config, 20) {
                 Ok(spy) => {
                     if let Err(_) = initialized_tx.send(Ok(spy.version.clone())) {
                         return;

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -86,10 +86,6 @@ class TestPyspy(unittest.TestCase):
         if v.major < 3 or v.minor < 6:
             return
 
-        # this also doesn't currently work on armv7
-        if platform.machine().startswith("armv7"):
-            return
-
         profile = self._sample_process(
             _get_script("thread_names.py"),
             ["--threads", "--idle"],

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -102,12 +102,12 @@ fn test_long_sleep() {
 
     // Make sure the stack trace is what we expect
     assert_eq!(trace.frames[0].name, "longsleep");
-    assert_eq!(trace.frames[0].filename, "./tests/scripts/longsleep.py");
+    assert_eq!(trace.frames[0].short_filename, Some("longsleep.py".to_owned()));
     assert_eq!(trace.frames[0].line, 5);
 
     assert_eq!(trace.frames[1].name, "<module>");
     assert_eq!(trace.frames[1].line, 9);
-    assert_eq!(trace.frames[0].filename, "./tests/scripts/longsleep.py");
+    assert_eq!(trace.frames[1].short_filename, Some("longsleep.py".to_owned()));
 
     assert!(!traces[0].owns_gil);
 
@@ -199,12 +199,12 @@ fn test_unicode() {
     let trace = &traces[0];
 
     assert_eq!(trace.frames[0].name, "function1");
-    assert_eq!(trace.frames[0].filename, "./tests/scripts/unicode💩.py");
+    assert_eq!(trace.frames[0].short_filename, Some("unicode💩.py".to_owned()));
     assert_eq!(trace.frames[0].line, 6);
 
     assert_eq!(trace.frames[1].name, "<module>");
     assert_eq!(trace.frames[1].line, 9);
-    assert_eq!(trace.frames[0].filename, "./tests/scripts/unicode💩.py");
+    assert_eq!(trace.frames[1].short_filename, Some("unicode💩.py".to_owned()));
 
     assert!(!traces[0].owns_gil);
 }
@@ -260,11 +260,7 @@ fn test_local_vars() {
     assert_eq!(local3.name, "local3");
     assert!(!local3.arg);
 
-    #[cfg(target_pointer_width = "64")]
     assert_eq!(local3.repr, Some("123456789123456789".to_owned()));
-
-    #[cfg(target_pointer_width = "32")]
-    assert_eq!(local3.repr, Some("+bigint".to_owned()));
 
     let local4 = &locals[6];
     assert_eq!(local4.name, "local4");


### PR DESCRIPTION
Fix thread_names on armv7 - by fixing how we were copying long integers on 32 bit systems.
The threadids were overflowing the copy_long code, leading to incorrect results in thread names
(and in copying local variables in the dump command).