### PR TITLE
Document Python 3.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ py-spy is extremely low overhead: it is written in Rust for speed and doesn't ru
 in the same process as the profiled Python program. This means py-spy is safe to use against production Python code.
 
 py-spy works on Linux, OSX, Windows and FreeBSD, and supports profiling all recent versions of the CPython
-interpreter (versions 2.3-2.7 and 3.3-3.8).
+interpreter (versions 2.3-2.7 and 3.3-3.9).
 
 ## Installation
 


### PR DESCRIPTION
CI is testing 3.9.x, and releases since 0.3.4 have claimed some level of support, so it looks like Python 3.9 is supported.