### PR TITLE
 Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ OSX always requires running as root, but on Linux it depends on how you are laun
 security settings.
 
 On Linux the default configuration is to require root permissions when attaching to a process that isn't a child.
-For py-spy this means you can profile without root access by getting py-spy to create the process (```py-spy -- python myprogram.py```) but attaching to an existing process by specifying a PID will usually require root (```sudo py-spy --pid 123456```).
+For py-spy this means you can profile without root access by getting py-spy to create the process
+(```py-spy record  -- python myprogram.py```) but attaching to an existing process by specifying a
+PID will usually require root (```sudo py-spy record --pid 123456```).
 You can remove this restriction on Linux by setting the [ptrace_scope sysctl variable](https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection).
 
 ### How do you detect if a thread is idle or not?


### PR DESCRIPTION
The sudo section of the README including invalid options for running py-spy.
Closes #395