### PR TITLE
Specify speedscope units

### DIFF
--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -26,9 +26,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+use std::io::Write;
 use std;
 use std::collections::HashMap;
-use std::fs::File;
 
 
 use failure::Error;
@@ -67,7 +67,7 @@ impl Flamegraph {
         self.counts.iter().map(|(k, v)| format!("{} {}", k, v)).collect()
     }
 
-    pub fn write(&self, w: &File) -> Result<(), Error> {
+    pub fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
         let mut opts =  Options::default();
         opts.direction = Direction::Inverted;
         opts.min_width = 0.1;
@@ -79,8 +79,7 @@ impl Flamegraph {
         Ok(())
     }
 
-    pub fn write_raw(&self, w: &mut File) -> Result<(), Error> {
-        use std::io::Write;
+    pub fn write_raw(&self, w: &mut dyn Write) -> Result<(), Error> {
         for line in self.get_lines() {
             w.write_all(line.as_bytes())?;
             w.write_all(b"\n")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ impl Recorder for RawFlamegraph {
 fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error> {
     let mut output: Box<dyn Recorder> = match config.format {
         Some(FileFormat::flamegraph) => Box::new(flamegraph::Flamegraph::new(config.show_line_numbers)),
-        Some(FileFormat::speedscope) =>  Box::new(speedscope::Stats::new(config.show_line_numbers)),
+        Some(FileFormat::speedscope) =>  Box::new(speedscope::Stats::new(config.show_line_numbers, config.sampling_rate)),
         Some(FileFormat::raw) => Box::new(RawFlamegraph(flamegraph::Flamegraph::new(config.show_line_numbers))),
         None => return Err(format_err!("A file format is required to record samples"))
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ mod timer;
 mod utils;
 mod version;
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -115,14 +115,14 @@ fn sample_console(pid: remoteprocess::Pid,
 
 pub trait Recorder {
     fn increment(&mut self, trace: &StackTrace) -> Result<(), Error>;
-    fn write(&self, w: &mut std::fs::File) -> Result<(), Error>;
+    fn write(&self, w: &mut dyn Write) -> Result<(), Error>;
 }
 
 impl Recorder for speedscope::Stats {
     fn increment(&mut self, trace: &StackTrace) -> Result<(), Error> {
         Ok(self.record(trace)?)
     }
-    fn write(&self, w: &mut std::fs::File) -> Result<(), Error> {
+    fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
         self.write(w)
     }
 }
@@ -131,7 +131,7 @@ impl Recorder for flamegraph::Flamegraph {
     fn increment(&mut self, trace: &StackTrace) -> Result<(), Error> {
         Ok(self.increment(trace)?)
     }
-    fn write(&self, w: &mut std::fs::File) -> Result<(), Error> {
+    fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
         self.write(w)
     }
 }
@@ -143,7 +143,7 @@ impl Recorder for RawFlamegraph {
         Ok(self.0.increment(trace)?)
     }
 
-    fn write(&self, w: &mut std::fs::File) -> Result<(), Error> {
+    fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
         self.0.write_raw(w)
     }
 }

--- a/src/speedscope.rs
+++ b/src/speedscope.rs
@@ -29,7 +29,6 @@ SOFTWARE.
 use std::collections::{HashMap};
 use std::io;
 use std::io::Write;
-use std::fs::File;
 
 use crate::stack_trace;
 use remoteprocess::Tid;
@@ -217,7 +216,7 @@ impl Stats {
         Ok(())
     }
 
-    pub fn write(&self, w: &mut File) -> Result<(), Error> {
+    pub fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
         let json = serde_json::to_string(&SpeedscopeFile::new(&self.samples, &self.frames, &self.thread_name_map))?;
         writeln!(w, "{}", json)?;
         Ok(())


### PR DESCRIPTION
We use the sampling rate from the command line arguments to output the correct time units, so that speedscope profiles will show correct time units.

Note: we cannot use static compile time generics to provide the `Write` trait usage, because `Recorder` is used as a trait object, and as such cannot include generic parameters.

See #294 