### PR TITLE
Use Rust 1.52.1 for FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,8 @@ freebsd_task:
   name: $TOOLCHAIN x86_64-unknown-freebsd
   env:
     matrix:
-      - TOOLCHAIN: stable
+        # we seem to be broken on rust 1.53 https://github.com/benfred/py-spy/pull/407
+      - TOOLCHAIN: 1.52.1
     GITHUB_TOKEN: ENCRYPTED[67283c0b5c9880ac3b7d8fb0335c4b24f95c62dab30b5379dca192600801c380a41f7436c7daaebfaa8f1381237a8412]
   setup_script:
     - pkg install -y curl bash python


### PR DESCRIPTION
The latest version of Rust (1.53) is causing unittest failures in our FreeBSD
CI. Use Rust 1.52.1 instead