### PR TITLE
Add a subcommand to generate shell completions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg, crate_description, crate_name, crate_version, arg_enum, value_t};
+use clap::{App, AppSettings, Arg, crate_description, crate_name, crate_version, arg_enum, value_t};
 use remoteprocess::Pid;
 
 /// Options on how to collect samples from a python process
@@ -222,6 +222,13 @@ impl Config {
                 .long("json")
                 .help("Format output as JSON"));
 
+        let completions = clap::SubCommand::with_name("completions")
+            .about("Generate shell completions")
+            .setting(AppSettings::Hidden)
+            .arg(Arg::with_name("shell")
+                .possible_values(&clap::Shell::variants())
+                .help("Shell type"));
+
         // add native unwinding if appropiate
         #[cfg(unwind)]
         let record = record.arg(native.clone());
@@ -238,7 +245,7 @@ impl Config {
         #[cfg(not(target_os="freebsd"))]
         let dump = dump.arg(nonblocking.clone());
 
-        let matches = App::new(crate_name!())
+        let mut app = App::new(crate_name!())
             .version(crate_version!())
             .about(crate_description!())
             .setting(clap::AppSettings::InferSubcommands)
@@ -248,7 +255,8 @@ impl Config {
             .subcommand(record)
             .subcommand(top)
             .subcommand(dump)
-            .get_matches_from_safe(args)?;
+            .subcommand(completions);
+        let matches = app.clone().get_matches_from_safe(args)?;
         info!("Command line args: {:?}", matches);
 
         let mut config = Config::default();
@@ -268,6 +276,11 @@ impl Config {
             },
             "top" => {
                 config.sampling_rate = value_t!(matches, "rate", u64)?;
+            }
+            "completions" => {
+                let shell = value_t!(matches.value_of("shell"), clap::Shell).unwrap_or_else(|e| e.exit());
+                app.gen_completions_to(crate_name!(), shell, &mut std::io::stdout());
+                std::process::exit(0);
             }
             _ => {}
         }


### PR DESCRIPTION
This can be used by Homebrew formula to automatically generate shell completions. 

```bash
$ py-spy completions --help
py-spy-completions
Generate shell completions

USAGE:
    py-spy completions [shell]

OPTIONS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <shell>    Shell type [possible values: zsh, bash, fish, powershell, elvish]
```