### PR TITLE
Fix duplicate ':' in dump output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,15 @@ pip install py-spy
 ```
 
 You can also download prebuilt binaries from the [GitHub Releases
-Page](https://github.com/benfred/py-spy/releases). This includes binaries for ARM and FreeBSD,
-which can't be installed using pip.
+Page](https://github.com/benfred/py-spy/releases).
 
 If you're a Rust user, py-spy can also be installed with: ```cargo install py-spy```.
 
-On Arch Linux, [py-spy is in AUR](https://aur.archlinux.org/packages/py-spy/) and can be
-installed with ```yay -S py-spy```.
-
 On macOS, [py-spy is in Homebrew](https://formulae.brew.sh/formula/py-spy#default) and 
 can be installed with ```brew install py-spy```.
+
+On Arch Linux, [py-spy is in AUR](https://aur.archlinux.org/packages/py-spy/) and can be
+installed with ```yay -S py-spy```.
 
 On Alpine Linux, [py-spy is in testing repository](https://pkgs.alpinelinux.org/packages?name=py-spy&branch=edge&repo=testing) and
 can be installed with ```apk add py-spy --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted```.

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -48,10 +48,10 @@ pub fn print_traces(pid: Pid, config: &Config) -> Result<(), Error> {
                 let mut shown_locals = false;
                 for local in locals {
                     if local.arg && !shown_args {
-                        println!("        {}:", style("Arguments:").dim());
+                        println!("        {}", style("Arguments:").dim());
                         shown_args = true;
                     } else if !local.arg && !shown_locals {
-                        println!("        {}:", style("Locals:").dim());
+                        println!("        {}", style("Locals:").dim());
                         shown_locals = true;
                     }
 


### PR DESCRIPTION
The arguments/locals had an extra ':' at the end of the line - fix.
Also remove reference saying that ARM can't be installed via pip in README,
and that freebsd can be downloaded from the releases page.