### PR TITLE
Include threadid and processid in speedscope profile names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,11 @@ env:
 jobs:
   build-freebsd-amd64:
     runs-on: macos-latest
-
     strategy:
       matrix:
         box:
           - fbsd_13_0
-          # there seems to be an issue in curl https://github.com/curl/curl/issues/7400
-          # that causes this to fail frequently. commenting out for now
-          # - fbsd_12_2
-
+          - fbsd_12_2
     steps:
       - name: Cache vagrant boxes
         id: cache-vagrant-boxes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
       matrix:
         box:
           - fbsd_13_0
-          - fbsd_12_2
+          # there seems to be an issue in curl https://github.com/curl/curl/issues/7400
+          # that causes this to fail frequently. commenting out for now
+          # - fbsd_12_2
 
     steps:
       - name: Cache vagrant boxes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
           ln -sf ci/Vagrantfile Vagrantfile
           vagrant up ${{ matrix.box }}
       - name: Build
-        run: vagrant ssh ${{ matrix.box }} -- "cd /vagrant; cargo build --verbose"
+        run: vagrant ssh ${{ matrix.box }} -- "cd /vagrant; source $HOME/.cargo/env; cargo build --verbose"
       - name: Test
-        run: vagrant ssh ${{ matrix.box }} -- "cd /vagrant; cargo test"
+        run: vagrant ssh ${{ matrix.box }} -- "cd /vagrant; source $HOME/.cargo/env; cargo test"
 
 
   build-linux-armv7:

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     pkg bootstrap
     pkg install -y curl python llvm
-    su runner <<EOF
+    su vagrant <<EOF
     curl https://sh.rustup.rs -sSf | sh -s -- -y;
     EOF
   SHELL

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -31,9 +31,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     pkg bootstrap
     pkg install -y curl python llvm
-  SHELL
-
-  config.vm.provision "shell", privileged: false, inline: <<-SHELL
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    su runner <<EOF
+    curl https://sh.rustup.rs -sSf | sh -s -- -y;
+    EOF
   SHELL
 end

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -30,6 +30,10 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     pkg bootstrap
-    pkg install -y rust python llvm
+    pkg install -y curl python llvm
+  SHELL
+
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
   SHELL
 end

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ impl Recorder for RawFlamegraph {
 fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error> {
     let mut output: Box<dyn Recorder> = match config.format {
         Some(FileFormat::flamegraph) => Box::new(flamegraph::Flamegraph::new(config.show_line_numbers)),
-        Some(FileFormat::speedscope) =>  Box::new(speedscope::Stats::new(config.show_line_numbers, config.sampling_rate)),
+        Some(FileFormat::speedscope) =>  Box::new(speedscope::Stats::new(config)),
         Some(FileFormat::raw) => Box::new(RawFlamegraph(flamegraph::Flamegraph::new(config.show_line_numbers))),
         None => return Err(format_err!("A file format is required to record samples"))
     };

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import re
 import tempfile
 import unittest
 from collections import defaultdict, namedtuple
@@ -93,7 +94,8 @@ class TestPyspy(unittest.TestCase):
             )
             expected_thread_names = set("CustomThreadName-" + str(i) for i in range(10))
             expected_thread_names.add("MainThread")
-            actual_thread_names = {p[0] for p in profile}
+            name_re = re.compile(r"\"(.*)\"")
+            actual_thread_names = {name_re.search(p[0]).groups()[0] for p in profile}
             if expected_thread_names == actual_thread_names:
                 break
         if expected_thread_names != actual_thread_names:


### PR DESCRIPTION
Include the thread id, and process id when profiling subprocesses,
in the profile name with speedscope. Closes #439