### PR TITLE
Fix FreeBSD CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,7 @@ jobs:
           ln -sf ci/Vagrantfile Vagrantfile
           vagrant up ${{ matrix.box }}
       - name: Build
-        run: vagrant ssh ${{ matrix.box }} -- "cd /vagrant; cargo build --verbose"
-      - name: Test
-        run: vagrant ssh ${{ matrix.box }} -- "cd /vagrant; cargo test"
+        run: vagrant ssh ${{ matrix.box }} -- "bash /vagrant/ci/test_freebsd.sh"
 
 
   build-linux-armv7:

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -28,8 +28,13 @@ Vagrant.configure("2") do |config|
     rsync__exclude: ".git/",
     rsync__auto: true
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", inline: <<~SHELL
     pkg bootstrap
-    pkg install -y rust python llvm
+    pkg install -y curl python llvm
+    su vagrant <<EOF
+    # we seem to be broken on rust 1.53 and 1.54 https://github.com/benfred/py-spy/pull/407
+    # so force using 1.52.1
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.52.1;
+    EOF
   SHELL
 end

--- a/ci/test_freebsd.sh
+++ b/ci/test_freebsd.sh
@@ -1,0 +1,4 @@
+source $HOME/.cargo/env
+cd /vagrant
+cargo build --release
+cargo test --release


### PR DESCRIPTION
There seems to be an issue in curl https://github.com/curl/curl/issues/7400
that causes building on freebsd to fail frequently. Circumvent this by
installing rust from rustup instead of the system package manager.