### PR TITLE
Remove FreeBSD CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,28 +13,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-freebsd-amd64:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        box:
-          - fbsd_13_0
-          - fbsd_12_2
-    steps:
-      - name: Cache vagrant boxes
-        id: cache-vagrant-boxes
-        uses: actions/cache@v2
-        with:
-          path: ~/.vagrant.d/
-          key: ${{ matrix.box }}-vm-cache
-      - uses: actions/checkout@v2
-      - name: Set up vagrant
-        run: |
-          ln -sf ci/Vagrantfile Vagrantfile
-          vagrant up ${{ matrix.box }}
-      - name: Build
-        run: vagrant ssh ${{ matrix.box }} -- "bash /vagrant/ci/test_freebsd.sh"
-
   build-linux-armv7:
     runs-on: [self-hosted, linux, arm]
     steps:


### PR DESCRIPTION
We're seeing "Too many requests" errors on downloading the vagrant box:

https://github.com/benfred/py-spy/pull/442/checks?check_run_id=3724575418

```
fbsd_12_2: Downloading: https://vagrantcloud.com/freebsd/boxes/FreeBSD-12.2-STABLE/versions/2021.09.23/providers/virtualbox.box

An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

The requested URL returned error: 429
```

This indicates to me that github actions might be rate limited in downloading boxes from
vagrantcloud. Disable until we can figure out an alternative