### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 * Show OS threadids in dump [#57](https://github.com/benfred/py-spy/issues/57)
 * Drop root permissions when starting new process [#116](https://github.com/benfred/py-spy/issues/116)
 * Support building for ARM processors [#89](https://github.com/benfred/py-spy/issues/89)
-* Python 3.8 compatability
+* Python 3.8 compatibility
 * Fix issues profiling functions with more than 4000 lines [#164](https://github.com/benfred/py-spy/issues/164)
 
 ## v0.1.11

--- a/ci/testdata/cython_test.c
+++ b/ci/testdata/cython_test.c
@@ -5114,7 +5114,7 @@ static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObj
     if (ctversion[0] != rtversion[0] || ctversion[2] != rtversion[2]) {
         char message[200];
         PyOS_snprintf(message, sizeof(message),
-                      "compiletime version %s of module '%.100s' "
+                      "compile time version %s of module '%.100s' "
                       "does not match runtime version %s",
                       ctversion, __Pyx_MODULE_NAME, rtversion);
         return PyErr_WarnEx(NULL, message, 1);

--- a/generate_bindings.py
+++ b/generate_bindings.py
@@ -142,7 +142,7 @@ def extract_bindings(cpython_path, version, configure=False):
     if ret:
         return ret
 
-    # write the file out to the appropiate place, disabling some warnings
+    # write the file out to the appropriate place, disabling some warnings
     with open(os.path.join("src", "python_bindings", version.replace(".", "_") + ".rs"), "w") as o:
         o.write(f"// Generated bindings for python {version}\n")
         o.write("#![allow(dead_code)]\n")

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ impl Config {
         let nonblocking = Arg::with_name("nonblocking")
                     .long("nonblocking")
                     .help("Don't pause the python process when collecting samples. Setting this option will reduce \
-                          the perfomance impact of sampling, but may lead to inaccurate results");
+                          the performance impact of sampling, but may lead to inaccurate results");
 
         let rate = Arg::with_name("rate")
                     .short("r")
@@ -241,7 +241,7 @@ impl Config {
                 .possible_values(&clap::Shell::variants())
                 .help("Shell type"));
 
-        // add native unwinding if appropiate
+        // add native unwinding if appropriate
         #[cfg(unwind)]
         let record = record.arg(native.clone());
         #[cfg(unwind)]

--- a/src/console_viewer.rs
+++ b/src/console_viewer.rs
@@ -393,7 +393,7 @@ impl Stats {
     }
 }
 
-// helper function for formating time values (hide decimals for larger values)
+// helper function for formatting time values (hide decimals for larger values)
 fn display_time(val: f64) -> String {
     if val > 1000.0 {
         format!("{:.0}", val)
@@ -407,7 +407,7 @@ fn display_time(val: f64) -> String {
 }
 
 /*
-This rest of this code is OS specific functions for setting up keyboard input appropiately
+This rest of this code is OS specific functions for setting up keyboard input appropriately
 (don't wait for a newline, and disable echo), and clearing the terminal window.
 
 This is all relatively low level, but there doesn't seem to be any great libraries out there
@@ -417,7 +417,7 @@ for doing this:
     https://github.com/ihalila/pancurses requires ncurses installed
  */
 
-// operating system specific details on setting up console to recieve single characters without displaying
+// operating system specific details on setting up console to receive single characters without displaying
 #[cfg(unix)]
 mod os_impl {
     use super::*;
@@ -462,7 +462,7 @@ mod os_impl {
     }
 }
 
-// operating system specific details on setting up console to recieve single characters
+// operating system specific details on setting up console to receive single characters
 #[cfg(windows)]
 mod os_impl {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,7 +397,7 @@ fn pyspy_main() -> Result<(), Error> {
             }
         }
 
-        // kill it so we don't have dangling processess
+        // kill it so we don't have dangling processes
         if command.kill().is_err() {
             // I don't actually care if we failed to kill ... most times process is already done
             // eprintln!("Error killing child process {}", e);

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -154,7 +154,7 @@ impl NativeStack {
         if check_python {
             if let Some(ref function) = frame.function {
                 // We want to include some internal python functions. For example, calls like time.sleep
-                // or os.kill etc are implemented as builtins in the interpeter and filtering them out
+                // or os.kill etc are implemented as builtins in the interpreter and filtering them out
                 // is misleading. Create a set of whitelisted python function prefixes to include
                 lazy_static! {
                     static ref WHITELISTED_PREFIXES: HashSet<&'static str> = {

--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -45,10 +45,10 @@ pub fn copy_bytes<T: BytesObject, P: ProcessMemory>(ptr: * const T, process: &P)
     Ok(process.copy(obj.address(ptr as usize), size as usize)?)
 }
 
-/// Copys a i64 from a PyLongObject. Returns the value + if it overflowed
+/// Copies a i64 from a PyLongObject. Returns the value + if it overflowed
 pub fn copy_long(process: &remoteprocess::Process, addr: usize) -> Result<(i64, bool), Error> {
     // this is PyLongObject for a specific version of python, but this works since it's binary compatible
-    // layout across versions we're targetting
+    // layout across versions we're targeting
     let value = process.copy_pointer(addr as *const crate::python_bindings::v3_7_0::PyLongObject)?;
     let negative: i64 = if value.ob_base.ob_size < 0 { -1 } else { 1 };
     let size = value.ob_base.ob_size * (negative as isize);
@@ -79,7 +79,7 @@ pub fn copy_long(process: &remoteprocess::Process, addr: usize) -> Result<(i64, 
     }
 }
 
-/// Copys a i64 from a python 2.7 PyIntObject
+/// Copies a i64 from a python 2.7 PyIntObject
 pub fn copy_int(process: &remoteprocess::Process, addr: usize) -> Result<i64, Error> {
     let value = process.copy_pointer(addr as *const crate::python_bindings::v2_7_15::PyIntObject)?;
     Ok(value.ob_ival as i64)
@@ -190,7 +190,7 @@ pub fn format_variable<I>(process: &remoteprocess::Process, version: &Version, a
     let formatted = if flags & PY_TPFLAGS_INT_SUBCLASS != 0 {
         format_int(copy_int(process, addr)?)
     } else if flags & PY_TPFLAGS_LONG_SUBCLASS != 0 {
-        // we don't handle arbitray sized integer values (max is 2**60)
+        // we don't handle arbitrary sized integer values (max is 2**60)
         let (value, overflowed) = copy_long(process, addr)?;
          if overflowed {
             if value > 0 { "+bigint".to_owned() } else { "-bigint".to_owned() }
@@ -271,7 +271,7 @@ pub fn format_variable<I>(process: &remoteprocess::Process, version: &Version, a
 #[cfg(test)]
 pub mod tests {
     // the idea here is to create various cpython interpretator structs locally
-    // and then test out that the above code handles appropiately
+    // and then test out that the above code handles appropriately
     use super::*;
     use remoteprocess::LocalProcess;
     use crate::python_bindings::v3_7_0::{PyBytesObject, PyVarObject, PyUnicodeObject, PyASCIIObject};

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -203,7 +203,7 @@ impl PythonSpy {
             thread_activity.insert(threadid, thread.active()?);
         }
 
-        // Lock the process if appropiate. Note we have to lock AFTER getting the thread
+        // Lock the process if appropriate. Note we have to lock AFTER getting the thread
         // activity status from the OS (otherwise each thread would report being inactive always).
         // This has the potential for race conditions (in that the thread activity could change
         // between getting the status and locking the thread, but seems unavoidable right now
@@ -289,7 +289,7 @@ impl PythonSpy {
 
             traces.push(trace);
 
-            // This seems to happen occasionally when scanning BSS addresses for valid interpeters
+            // This seems to happen occasionally when scanning BSS addresses for valid interpreters
             if traces.len() > 4096 {
                 return Err(format_err!("Max thread recursion depth reached"));
             }
@@ -688,7 +688,7 @@ fn check_interpreter_addresses(addrs: &[usize],
         Err(format_err!("Failed to find a python interpreter in the .data section"))
     }
 
-    // different versions have different layouts, check as appropiate
+    // different versions have different layouts, check as appropriate
     match version {
         Version{major: 2, minor: 3..=7, ..} => check::<v2_7_15::_is>(addrs, maps, process),
         Version{major: 3, minor: 3, ..} => check::<v3_3_7::_is>(addrs, maps, process),
@@ -776,7 +776,7 @@ impl PythonProcessInfo {
                             .map_err(|err| err.into())
                     }
 
-                    // For OSX, need to adjust main binary symbols by substracting _mh_execute_header
+                    // For OSX, need to adjust main binary symbols by subtracting _mh_execute_header
                     // (which we've added to by map.start already, so undo that here)
                     #[cfg(target_os = "macos")]
                     {
@@ -988,7 +988,7 @@ mod tests {
         assert!(is_python_lib("/usr/local/lib/libpython3.8m.so"));
         assert!(is_python_lib("/usr/lib/libpython2.7u.so"));
 
-        // don't blindly match libraries with pytohn in the name (boost_python etc)
+        // don't blindly match libraries with python in the name (boost_python etc)
         assert!(!is_python_lib("/usr/lib/libboost_python.so"));
         assert!(!is_python_lib("/usr/lib/x86_64-linux-gnu/libboost_python-py27.so.1.58.0"));
         assert!(!is_python_lib("/usr/lib/libboost_python-py35.so"));

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -180,7 +180,7 @@ impl Sampler {
                 // Annotate each trace with the process info
                 for trace in traces.iter_mut() {
                     let pid = trace.pid;
-                    // Annotate each trace with the process info for the curren
+                    // Annotate each trace with the process info for the current
                     let process = process_info.entry(pid).or_insert_with(|| {
                         get_process_info(pid, &spies).map(|p| Arc::new(*p))
                     });

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -72,7 +72,7 @@ pub fn get_stack_traces<I>(interpreter: &I, process: &Process, lineno: LineNo) -
     while !threads.is_null() {
         let thread = process.copy_pointer(threads).context("Failed to copy PyThreadState")?;
         ret.push(get_stack_trace(&thread, process, false, lineno)?);
-        // This seems to happen occasionally when scanning BSS addresses for valid interpeters
+        // This seems to happen occasionally when scanning BSS addresses for valid interpreters
         if ret.len() > 4096 {
             return Err(format_err!("Max thread recursion depth reached"));
         }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -5,7 +5,7 @@ use winapi::um::timeapi;
 use rand;
 use rand_distr::{Exp, Distribution};
 
-/// Timer is an iterator that sleeps an appropiate amount of time between iterations
+/// Timer is an iterator that sleeps an appropriate amount of time between iterations
 /// so that we can sample the process a certain number of times a second.
 /// We're using an irregular sampling strategy to avoid aliasing effects that can happen
 /// if the target process runs code at a similar schedule as the profiler:
@@ -47,7 +47,7 @@ impl Iterator for Timer {
         // the amount of time from the previous line).
         self.desired += Duration::from_nanos(nanos as u64);
 
-        // sleep if appropiate, or warn if we are behind in sampling
+        // sleep if appropriate, or warn if we are behind in sampling
         if self.desired > elapsed {
             std::thread::sleep(self.desired - elapsed);
             Some(Ok(self.desired - elapsed))


### PR DESCRIPTION
[`codespell --ignore-words-list=als,crate,nd`](https://pypi.org/project/codespell/)