### PR TITLE
Add a subprocesses option for the dump command

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -253,7 +253,8 @@ impl Config {
             .arg(Arg::new("json")
                 .short('j')
                 .long("json")
-                .help("Format output as JSON"));
+                .help("Format output as JSON"))
+            .arg(subprocesses.clone());
 
         let completions = Command::new("completions")
             .about("Generate shell completions")
@@ -337,11 +338,11 @@ impl Config {
                 });
                 config.gil_only = matches.occurrences_of("gil") > 0;
                 config.include_idle = matches.occurrences_of("idle") > 0;
-                config.subprocesses = matches.occurrences_of("subprocesses") > 0;
             },
             _ => {}
         }
 
+        config.subprocesses = matches.occurrences_of("subprocesses") > 0;
         config.command = subcommand.to_owned();
 
         // options that can be shared between subcommands

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,7 @@ fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error>
 fn run_spy_command(pid: remoteprocess::Pid, config: &config::Config) -> Result<(), Error> {
     match config.command.as_ref() {
         "dump" =>  {
-            dump::print_traces(pid, config)?;
+            dump::print_traces(pid, config, None)?;
         },
         "record" => {
             record_samples(pid, config)?;


### PR DESCRIPTION
Adds the ability to print out stack traces from subprocesses
when running the dump command, like we can already do for
the record / top commands