### PR TITLE
Update release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,10 @@ categories:
     label: 
       - 'chore'
       - 'ci'
+      - 'dependencies'
+
+exclude-labels:
+  - 'skip-changelog'
 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.

--- a/.github/workflows/update_python_test.yml
+++ b/.github/workflows/update_python_test.yml
@@ -23,3 +23,6 @@ jobs:
             commit-message: Update tested python versions
             title: Update tested python versions
             branch: update-python-versons
+            labels: |
+                skip-changelog
+                dependencies


### PR DESCRIPTION
exclude 'skip_changelog', and automatically apply to the 'update tested python versions' workflow
changes.