### PR TITLE
Add flag to avoid filtering out native functions

### DIFF
--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -124,7 +124,7 @@ impl PythonSpy {
 
         #[cfg(unwind)]
         let native = if config.native {
-            Some(NativeStack::new(pid, python_info.python_binary, python_info.libpython_binary)?)
+            Some(NativeStack::new(pid, python_info.python_binary, python_info.libpython_binary, config.native_unfiltered)?)
         } else {
             None
         };


### PR DESCRIPTION
Add `--native-unfiltered` flag that disables most filtering of native
functions in stack traces. Useful to track all calls to libpython
functions from extensions, or to debug performance issues in Python
itself.

This is a potential solution for #437. The result is a bit noisy, and I'm
not sure this is a good implementation. It does the job for me though.