### PR TITLE
WIP: don't report subprocess names in SVG output

### DIFF
--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -182,7 +182,12 @@ fn get_locals<C: CodeObject, F: FrameObject, P: ProcessMemory>(code: &C, framept
 
 impl ProcessInfo {
     pub fn to_frame(&self) -> Frame {
-        Frame{name: format!("process {}:\"{}\"", self.pid, self.command_line),
+        let name = if self.parent.is_none() {
+            format!("process {}:\"{}\"", self.pid, self.command_line)
+        } else {
+            "subprocess".to_string()
+        };
+        Frame{name,
             filename: String::from(""),
             module: None, short_filename: None, line: 0, locals: None}
     }


### PR DESCRIPTION
I'd like some way of suppressing subprocess info in the flamegraph/SVG output.  This pull-request doesn't expose this option to the user, but seems to do the right thing when I run it.

The motivation is when using the `multiprocessing` module (e.g. the code below) and hence I don't really care which process the code is running inside, just that it's not in the main one probably.  I.e. when running the official version I get `n` processes that contain basically the same information and hence it seems to make sense to combine them into a single stack.  This transformation obviously doesn't make sense if the user is doing different things in each process, but for multiprocessing workloads this cleans up the output a lot.

I think this functionality should be exposed on the command-line somewhere, but wasn't sure how to do that nicely so left that out for the time being.

```python
from multiprocessing import Pool
from time import monotonic

def foo(x):
    t1 = monotonic() + 0.1
    while monotonic() < t1:
        x += sum(range(1024 * 1024))
    return x

def main():
    with Pool() as pool:
        print(pool.map(foo, range(100)))

if __name__ == "__main__":
    main()
```