### PR TITLE
Fix panic when virtual memory maps are empty

### DIFF
--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -764,7 +764,7 @@ impl PythonProcessInfo {
                     // If we failed to find the executable in the virtual memory maps, just take the first file we find
                     // sometimes on windows get_process_exe returns stale info =( https://github.com/benfred/py-spy/issues/40
                     // and on all operating systems I've tried, the exe is the first region in the maps
-                    &maps[0]
+                    &maps.first().ok_or_else(|| format_err!("Failed to get virtual memory maps from process"))?
                 }
             };
 


### PR DESCRIPTION
In https://github.com/benfred/py-spy/issues/503, there
are reports that py-spy panics - with the stack trace indicating
that its trying to load up a process with no virtual memory maps.

Fix by handling the case where maps are empty, to return an Err rather
than panicking