### PR TITLE
Use anyhow instead of failure for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,6 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca9b76e919fd83ccfb509f51b28c333c0e03f2221616e347a129215cec4e4a9"
@@ -91,21 +82,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line 0.17.0",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bindgen"
@@ -369,28 +345,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -868,6 +822,7 @@ dependencies = [
 name = "py-spy"
 version = "0.3.12"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap 3.2.15",
  "clap_complete",
@@ -875,7 +830,6 @@ dependencies = [
  "cpp_demangle",
  "ctrlc",
  "env_logger",
- "failure",
  "goblin",
  "indicatif",
  "inferno",
@@ -999,7 +953,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab91eb6b1c4c507a08d6fb6e2f38982a1e09923d19023506cba25aefcfc6e46f"
 dependencies = [
- "addr2line 0.18.0",
+ "addr2line",
  "goblin",
  "lazy_static",
  "libc",
@@ -1154,18 +1108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,12 +1189,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ build="build.rs"
 edition="2021"
 
 [dependencies]
+anyhow = "1"
 clap = {version="3.1", features=["wrap_help", "cargo", "derive"]}
 clap_complete="3.1"
 console = "0.15"
 ctrlc = "3"
 indicatif = "0.16"
 env_logger = "0.9"
-failure = "0.1.8"
 goblin = "0.5.3"
 inferno = "0.11.7"
 lazy_static = "1.4.0"

--- a/examples/dump_traces.rs
+++ b/examples/dump_traces.rs
@@ -3,7 +3,7 @@ use log::error;
 // Simple example of showing how to use the rust API to
 // print out stack traces from a python program
 
-fn print_python_stacks(pid: remoteprocess::Pid) -> Result<(), failure::Error> {
+fn print_python_stacks(pid: remoteprocess::Pid) -> Result<(), anyhow::Error> {
     // Create a new PythonSpy object with the default config options
     let config = py_spy::Config::default();
     let mut process = py_spy::PythonSpy::new(pid, &config)?;

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
-use failure::Error;
+use anyhow::Error;
 use goblin;
 use goblin::Object;
 use memmap::Mmap;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use clap::{ArgEnum, Arg, Command, crate_description, crate_name, crate_version, PossibleValue};
+use clap::{ArgEnum, Arg, Command, crate_description, crate_name, crate_version, PossibleValue, value_parser};
 use remoteprocess::Pid;
 
 /// Options on how to collect samples from a python process
@@ -260,7 +260,7 @@ impl Config {
             .about("Generate shell completions")
             .hide(true)
             .arg(Arg::new("shell")
-                .possible_values(clap_complete::Shell::possible_values())
+                .value_parser(value_parser!(clap_complete::Shell))
                 .help("Shell type"));
 
         // add native unwinding if appropriate

--- a/src/console_viewer.rs
+++ b/src/console_viewer.rs
@@ -6,8 +6,8 @@ use std::io::{Read, Write};
 use std::sync::{Mutex, Arc, atomic};
 use std::thread;
 
+use anyhow::Error;
 use console::{Term, style};
-use failure::Error;
 
 use crate::config::Config;
 use crate::stack_trace::{StackTrace, Frame};

--- a/src/cython.rs
+++ b/src/cython.rs
@@ -3,7 +3,7 @@ use std;
 use std::collections::{BTreeMap, HashMap};
 use regex::Regex;
 
-use failure::Error;
+use anyhow::Error;
 use lazy_static::lazy_static;
 
 use crate::utils::resolve_filename;

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,5 +1,5 @@
+use anyhow::Error;
 use console::{Term, style};
-use failure::Error;
 
 use crate::config::Config;
 use crate::python_spy::PythonSpy;

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -31,7 +31,7 @@ use std;
 use std::collections::HashMap;
 
 
-use failure::Error;
+use anyhow::Error;
 use inferno::flamegraph::{Direction, Options};
 
 use crate::stack_trace::StackTrace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Example:
 //!
 //! ```rust,no_run
-//! fn print_python_stacks(pid: py_spy::Pid) -> Result<(), failure::Error> {
+//! fn print_python_stacks(pid: py_spy::Pid) -> Result<(), anyhow::Error> {
 //!     // Create a new PythonSpy object with the default config options
 //!     let config = py_spy::Config::default();
 //!     let mut process = py_spy::PythonSpy::new(pid, &config)?;
@@ -25,7 +25,7 @@
 //! }
 //! ```
 #[macro_use]
-extern crate failure;
+extern crate anyhow;
 #[macro_use]
 extern crate log;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate failure;
+extern crate anyhow;
 #[macro_use]
 extern crate log;
 
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use console::style;
-use failure::Error;
+use anyhow::Error;
 
 use stack_trace::{StackTrace, Frame};
 use console_viewer::ConsoleViewer;
@@ -40,7 +40,7 @@ use chrono::{SecondsFormat, Local};
 
 #[cfg(unix)]
 fn permission_denied(err: &Error) -> bool {
-    err.iter_chain().any(|cause| {
+    err.chain().any(|cause| {
         if let Some(ioerror) = cause.downcast_ref::<std::io::Error>() {
             ioerror.kind() == std::io::ErrorKind::PermissionDenied
         } else if let Some(remoteprocess::Error::IOError(ioerror)) = cause.downcast_ref::<remoteprocess::Error>() {
@@ -439,12 +439,11 @@ fn main() {
         }
 
         eprintln!("Error: {}", err);
-        for (i, suberror) in err.iter_chain().enumerate() {
+        for (i, suberror) in err.chain().enumerate() {
             if i > 0 {
                 eprintln!("Reason: {}", suberror);
             }
         }
-        eprintln!("{}", err.backtrace());
         std::process::exit(1);
     }
 }

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use failure::Error;
+use anyhow::Error;
 
 use cpp_demangle::{DemangleOptions, BorrowedSymbol};
 use remoteprocess::{self, Pid};

--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -1,6 +1,6 @@
 use std;
 
-use failure::Error;
+use anyhow::Error;
 
 use remoteprocess::ProcessMemory;
 use crate::python_interpreters::{StringObject, BytesObject, InterpreterState, Object, TypeObject, TupleObject, ListObject};

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 #[cfg(windows)]
 use regex::RegexBuilder;
 
-use failure::{Error, ResultExt};
+use anyhow::{Error, Result, Context};
 use lazy_static::lazy_static;
 use remoteprocess::{Process, ProcessMemory, Pid, Tid};
 use proc_maps::{get_process_maps, MapRange};

--- a/src/python_threading.rs
+++ b/src/python_threading.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use failure::Error;
+use anyhow::Error;
 
 use crate::python_bindings::{v3_6_6, v3_7_0, v3_8_0, v3_9_5, v3_10_0};
 use crate::python_interpreters::{InterpreterState, Object, TypeObject};

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -4,7 +4,7 @@ use std::sync::{Mutex, Arc};
 use std::time::Duration;
 use std::thread;
 
-use failure::Error;
+use anyhow::Error;
 
 use remoteprocess::Pid;
 

--- a/src/speedscope.rs
+++ b/src/speedscope.rs
@@ -33,7 +33,7 @@ use std::io::Write;
 use crate::stack_trace;
 use remoteprocess::{Tid, Pid};
 
-use failure::{Error};
+use anyhow::{Error};
 use serde_derive::{Deserialize, Serialize};
 use serde_json;
 

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -1,7 +1,7 @@
 use std;
 use std::sync::Arc;
 
-use failure::{Error, ResultExt};
+use anyhow::{Context, Error, Result};
 
 use remoteprocess::{ProcessMemory, Pid, Process};
 use serde_derive::Serialize;

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use regex::bytes::Regex;
 use std;
 
-use failure::{Error};
+use anyhow::{Error};
 
 
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Use the anyhow crate instead of failure for errors. failure is unmaintained,
and hasn't been updated in 2 years.