### PR TITLE
Fix typos

### DIFF
--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -61,7 +61,7 @@ impl PythonSpy {
 
         let interpreter_address = get_interpreter_address(&python_info, &process, &version)?;
         info!("Found interpreter at 0x{:016x}", interpreter_address);
-    
+
         // lets us figure out which thread has the GIL
         let threadstate_address = get_threadstate_address(&python_info, &version, config)?;
 
@@ -180,7 +180,7 @@ impl PythonSpy {
 
             // python 3.11+ has the native thread id directly on the PyThreadState object,
             // for older versions of python, try using OS specific code to get the native
-            // thread id (doesn' work on freebsd, or on arm/i686 processors on linux)
+            // thread id (doesn't work on freebsd, or on arm/i686 processors on linux)
             if trace.os_thread_id.is_none() {
                 let mut os_thread_id = self._get_os_thread_id(python_thread_id, &interp)?;
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -116,7 +116,7 @@ impl Sampler {
         }
 
         // Create a new thread to periodically monitor for new child processes, and update
-        // the procesess map
+        // the processes map
         let spies = Arc::new(Mutex::new(spies));
         let monitor_spies = spies.clone();
         let monitor_config = config.clone();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -164,7 +164,7 @@ fn test_recursive() {
 
     // there used to be a problem where the top-level functions being returned
     // weren't actually entry points: https://github.com/benfred/py-spy/issues/56
-    // This was fixed by locking the process while we are profling it. Test that
+    // This was fixed by locking the process while we are profiling it. Test that
     // the fix works by generating some samples from a program that would exhibit
     // this behaviour
     let mut runner = TestRunner::new(Config::default(), "./tests/scripts/recursive.py");


### PR DESCRIPTION
Found via `codespell -L crate,nd,als`