### PR TITLE
Fix string copy test by using predictable struct memory layout for `AllocatedPyASCIIObject`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         rustup target add aarch64-apple-darwin
         pip install --upgrade maturin
-        maturin build --release -o dist --universal2
+        maturin build --release -o dist --target universal2-apple-darwin
       if: matrix.os == 'macos-latest'
     - name: Rename Wheels
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,18 +13,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # build-linux-armv7:
-  #   runs-on: [self-hosted, linux, arm]
-  #   steps:
-  #   - name: Setup python
-  #     run: |
-  #       pyenv global system
-  #       python --version
-  #   - uses: actions/checkout@v3
-  #   - name: Build
-  #     run: cargo build --verbose
-  #   - name: Run tests
-  #     run: cargo test
+  build-linux-armv7:
+    runs-on: [self-hosted, linux, arm]
+    steps:
+    - name: Setup python
+      run: |
+        pyenv global system
+        python --version
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test
 
   build:
     runs-on: ${{ matrix.os }}
@@ -216,33 +216,32 @@ jobs:
         run: sudo "PATH=$PATH" python tests/integration_test.py
         if: steps.osx_test1.outcome=='failure'
 
-  # Disabled on fork at madkinsz/py-spy because we do not have self-hosted runners
-  # test-wheel-linux-armv7:
-  #   name: Test ARMv7 Wheel
-  #   needs: [build-linux-cross]
-  #   runs-on: [self-hosted, linux, arm]
-  #   strategy:
-  #     matrix:
-  #       # we're installing the manylinux2014 wheel, so can
-  #       # only test out relatively recent versions of python
-  #       pyenv-python-version: [3.7.10, 3.8.9, 3.9.4]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: wheels
-  #     - name: Setup pyenv
-  #       run: |
-  #         # build the version of python if not installed already
-  #         # (note this relies on pyenv being setup already)
-  #         pyenv install -s ${{ matrix.pyenv-python-version }}
-  #         pyenv global ${{ matrix.pyenv-python-version }}
-  #         python --version
-  #     - name: Install wheel
-  #       run: |
-  #         pip install --force-reinstall --no-index --find-links . py-spy
-  #     - name: Test Wheel
-  #       run: python tests/integration_test.py
+  test-wheel-linux-armv7:
+    name: Test ARMv7 Wheel
+    needs: [build-linux-cross]
+    runs-on: [self-hosted, linux, arm]
+    strategy:
+      matrix:
+        # we're installing the manylinux2014 wheel, so can
+        # only test out relatively recent versions of python
+        pyenv-python-version: [3.7.10, 3.8.9, 3.9.4]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+      - name: Setup pyenv
+        run: |
+          # build the version of python if not installed already
+          # (note this relies on pyenv being setup already)
+          pyenv install -s ${{ matrix.pyenv-python-version }}
+          pyenv global ${{ matrix.pyenv-python-version }}
+          python --version
+      - name: Install wheel
+        run: |
+          pip install --force-reinstall --no-index --find-links . py-spy
+      - name: Test Wheel
+        run: python tests/integration_test.py
 
   release:
     name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,18 +13,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-linux-armv7:
-    runs-on: [self-hosted, linux, arm]
-    steps:
-    - name: Setup python
-      run: |
-        pyenv global system
-        python --version
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test
+  # build-linux-armv7:
+  #   runs-on: [self-hosted, linux, arm]
+  #   steps:
+  #   - name: Setup python
+  #     run: |
+  #       pyenv global system
+  #       python --version
+  #   - uses: actions/checkout@v3
+  #   - name: Build
+  #     run: cargo build --verbose
+  #   - name: Run tests
+  #     run: cargo test
 
   build:
     runs-on: ${{ matrix.os }}
@@ -216,38 +216,39 @@ jobs:
         run: sudo "PATH=$PATH" python tests/integration_test.py
         if: steps.osx_test1.outcome=='failure'
 
-  test-wheel-linux-armv7:
-    name: Test ARMv7 Wheel
-    needs: [build-linux-cross]
-    runs-on: [self-hosted, linux, arm]
-    strategy:
-      matrix:
-        # we're installing the manylinux2014 wheel, so can
-        # only test out relatively recent versions of python
-        pyenv-python-version: [3.7.10, 3.8.9, 3.9.4]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-      - name: Setup pyenv
-        run: |
-          # build the version of python if not installed already
-          # (note this relies on pyenv being setup already)
-          pyenv install -s ${{ matrix.pyenv-python-version }}
-          pyenv global ${{ matrix.pyenv-python-version }}
-          python --version
-      - name: Install wheel
-        run: |
-          pip install --force-reinstall --no-index --find-links . py-spy
-      - name: Test Wheel
-        run: python tests/integration_test.py
+  # Disabled on fork at madkinsz/py-spy because we do not have self-hosted runners
+  # test-wheel-linux-armv7:
+  #   name: Test ARMv7 Wheel
+  #   needs: [build-linux-cross]
+  #   runs-on: [self-hosted, linux, arm]
+  #   strategy:
+  #     matrix:
+  #       # we're installing the manylinux2014 wheel, so can
+  #       # only test out relatively recent versions of python
+  #       pyenv-python-version: [3.7.10, 3.8.9, 3.9.4]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: wheels
+  #     - name: Setup pyenv
+  #       run: |
+  #         # build the version of python if not installed already
+  #         # (note this relies on pyenv being setup already)
+  #         pyenv install -s ${{ matrix.pyenv-python-version }}
+  #         pyenv global ${{ matrix.pyenv-python-version }}
+  #         python --version
+  #     - name: Install wheel
+  #       run: |
+  #         pip install --force-reinstall --no-index --find-links . py-spy
+  #     - name: Test Wheel
+  #       run: python tests/integration_test.py
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [test-wheels, test-wheel-linux-armv7]
+    needs: [test-wheels]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [test-wheels]
+    needs: [test-wheels, test-wheel-linux-armv7]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -333,6 +333,7 @@ pub mod tests {
     }
 
     #[allow(dead_code)]
+    #[repr(C)] // Rust can optimize the layout of this struct and break our pointer arithmetic
     pub struct AllocatedPyASCIIObject {
         pub base: PyASCIIObject,
         pub storage: [u8; 4096]


### PR DESCRIPTION
Resolves failing test `test_copy_string`:

```
---- python_data_access::tests::test_copy_string stdout ----
copied: "\0\0\0\0\0\0\0\0\0\0\0\0\0"
thread 'python_data_access::tests::test_copy_string' panicked at 'assertion failed: `(left == right)`
  left: `"\0\0\0\0\0\0\0\0\0\0\0\0\0"`,
 right: `"function_name"`', src/python_data_access.rs:490:9
 ```

or 

```
 ---- python_data_access::tests::test_copy_string stdout ----
thread 'python_data_access::tests::test_copy_string' panicked at 'called `Result::unwrap()`
 on an `Err` value: invalid utf-8 sequence of 1 bytes from index 2', src/python_data_access.rs:370:58
```

which occurs due to a failure to copy test data during into a `AllocatedPyASCIIObject` during `to_asciiobject` due to optimization of the struct layout by Rust. We can ask for a C-compatible layout to get a consistent layout for pointer arithmetic.


See passing builds at https://github.com/madkinsz/py-spy/pull/3
See failing builds at https://github.com/madkinsz/py-spy/pull/1 or https://github.com/benfred/py-spy/pull/541