### PR TITLE
Fix freebsd builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
         path: dist
 
   build-freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
     rsync__exclude: [".git", ".vagrant.d"]
 
   config.vm.provision "shell", inline: <<~SHELL
-    pkg install -y python devel/llvm90
+    pkg install -y python devel/llvm11
   SHELL
 
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
Fixes builds for freebsd

- Update freebsd build runner to `macos-latest`
- Use a newer version of llvm (previous version is not found)

See failure at https://github.com/benfred/py-spy/actions/runs/4984539891/jobs/8946184710
Will require https://github.com/benfred/py-spy/pull/574
View successful build at https://github.com/madkinsz/py-spy/pull/7