### PR TITLE
Add 'whitelist' argument to limit the subprocesses being monitored

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -435,8 +435,7 @@ impl Config {
         config.subprocesses = matches.occurrences_of("subprocesses") > 0;
         config.command = subcommand.to_owned();
         config.whitelist =  matches.value_of("whitelist")
-            .map(|p| p.split(',').map(String::from).collect());
-        
+            .map(|p| p.split(',').map(|s| String::from(s.trim())).filter(|s| !s.is_empty()).collect());
 
         // options that can be shared between subcommands
         config.pid = matches

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::type_complexity)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -147,6 +148,8 @@ impl Sampler {
         let monitor_spies = spies.clone();
         let monitor_config = config.clone();
         std::thread::spawn(move || {
+            let mut checked_pids = HashSet::new();
+
             while process.exe().is_ok() {
                 match monitor_spies.lock() {
                     Ok(mut spies) => {
@@ -154,15 +157,18 @@ impl Sampler {
                             .child_processes()
                             .expect("failed to get subprocesses")
                         {
-                            if spies.contains_key(&childpid) {
-                                continue;
+                            if checked_pids.insert(childpid) == false {
+                                continue; // Already in set
                             }
-                            match PythonSpyThread::new(childpid, Some(parentpid), &monitor_config) {
-                                Ok(spy) => {
-                                    spies.insert(childpid, spy);
-                                }
-                                Err(e) => {
-                                    warn!("Failed to create spy for {}: {}", childpid, e);
+
+                            if is_process_whitelisted(childpid, &monitor_config) {
+                                match PythonSpyThread::new(childpid, Some(parentpid), &monitor_config) {
+                                    Ok(spy) => {
+                                        spies.insert(childpid, spy);
+                                    }
+                                    Err(e) => {
+                                        warn!("Failed to create spy for {}: {}", childpid, e);
+                                    }
                                 }
                             }
                         }
@@ -414,4 +420,32 @@ fn get_process_info(pid: Pid, spies: &HashMap<Pid, PythonSpyThread>) -> Option<B
             command_line: spy.command_line.clone(),
         })
     })
+}
+
+fn get_process_name(pid: Pid) -> Result<String, Error>{
+    let proc = remoteprocess::Process::new(pid)?;
+    let exe_path = proc.exe()?;
+    let exe_name = Path::new(&exe_path).file_stem().ok_or(anyhow!("Failed to get process name"))?;
+
+    Ok(exe_name.to_str().unwrap().into())
+}
+
+// True if no/empty whitelist, or processs name in whitelist
+fn is_process_whitelisted(pid: Pid, monitor_config: &Config) -> bool {
+    if monitor_config.whitelist.is_none(){
+        return true;
+    }
+    let whitelist = monitor_config.whitelist.as_ref().unwrap();
+    if whitelist.len() == 0 {
+        return true;
+    }
+    match get_process_name(pid) {
+        Ok(proc_name) => {
+            whitelist.iter().any(|item|item.eq_ignore_ascii_case(&proc_name))
+        }
+        Err(_) => {
+            warn!("Failed to get process name for PID: {}", pid);
+            false
+        }
+    }
 }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -438,16 +438,14 @@ fn should_spy_process(pid: Pid, monitor_config: &Config) -> bool {
         }
         match get_process_name(pid) {
             Ok(proc_name) => {
-                whitelist.iter().any(|item|item.eq_ignore_ascii_case(&proc_name))
+                return whitelist.iter().any(|item|item.eq_ignore_ascii_case(&proc_name));
             }
             Err(_) => {
                 warn!("Failed to get process name for PID: {}", pid);
-                false
+                return false;
             }
         }
     } else {
         return true;
     }
-
-
 }


### PR DESCRIPTION
Hello!

The main reasoning behind this change is the following issue:
https://github.com/benfred/py-spy/issues/561

This changes the thread that checks for new subprocesses, and calls a new ‘should_spy_process’ function to determine if the subprocess should be spied on. It currently checks if the process name if within the whitelist, if no whitelist is provided then it reverts to the old behaviour.

It is important this check happens before checking the symbols, so it will reduce the CPU usage as mentioned in the issue above.
Example usage: 
py-spy.exe record -o speedscope.json -f speedscope --pid x --subprocesses --whitelist=python,pythonw,ect

Let me know what your thoughts are, many thanks!
William Rosen
