### PR TITLE
Don't include undef sym refs when building map of symbol definitions

### DIFF
--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -185,6 +185,10 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
             }
 
             for sym in elf.syms.iter() {
+                // Skip undefined symbols.
+                if sym.st_shndx == goblin::elf::section_header::SHN_UNDEF as usize {
+                    continue;
+                }
                 // Skip imported symbols
                 if sym.is_import()
                     || (bss_end != 0
@@ -203,6 +207,10 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                 }
             }
             for dynsym in elf.dynsyms.iter() {
+                // Skip undefined symbols.
+                if dynsym.st_shndx == goblin::elf::section_header::SHN_UNDEF as usize {
+                    continue;
+                }
                 // Skip imported symbols
                 if dynsym.is_import()
                     || (bss_end != 0


### PR DESCRIPTION
Previously, we'd count undefined symbols references in the map of symbols defined in a binary, which could cause e.g. py-spy to misattribute an undefined ref to `_PyRuntime` in some location other than libpython.so as the definition.