### PR TITLE
Support facebook's cinder.3.8 Python fork

### DIFF
--- a/src/coredump.rs
+++ b/src/coredump.rs
@@ -441,6 +441,7 @@ mod test {
             minor: 9,
             patch: 13,
             release_flags: "".to_owned(),
+            build_metadata: None,
         };
         let python_core = PythonCoreDump {
             core,

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -222,7 +222,10 @@ pub mod pyruntime {
             },
             Version {
                 major: 3, minor: 8, ..
-            } => Some(1368),
+            } => match version.build_metadata.as_deref() {
+                Some("cinder") => Some(1384),
+                _ => Some(1368),
+            },
             Version {
                 major: 3,
                 minor: 9..=10,

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -318,6 +318,7 @@ where
                             minor,
                             patch: 0,
                             release_flags: "".to_owned(),
+                            build_metadata: None,
                         });
                     }
                 }


### PR DESCRIPTION
Facebook's cinder.3.8 Python fork uses a different offset for the current tstate.  Use the buildmetadata to detect and special case this (https://github.com/facebookincubator/cinder/blob/cinder/3.8/Include/patchlevel.h#L26).