### PR TITLE
Re-fetch thread ID in native profiling for Python 3.11

### DIFF
--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -249,8 +249,11 @@ impl PythonSpy {
 
             // python 3.11+ has the native thread id directly on the PyThreadState object,
             // for older versions of python, try using OS specific code to get the native
-            // thread id (doesn't work on freebsd, or on arm/i686 processors on linux)
-            if trace.os_thread_id.is_none() {
+            // thread id (doesn't work on freebsd, or on arm/i686 processors on linux).
+            // On native profiling of forked processes where the fork happens in native code,
+            // Python 3.11+'s native thread ID is not always updated. In that case, also re-fetch
+            // the native thread ID from the OS.
+            if trace.os_thread_id.is_none() || self.config.native {
                 let mut os_thread_id = self._get_os_thread_id(python_thread_id, &interp)?;
 
                 // linux can see issues where pthread_ids get recycled for new OS threads,


### PR DESCRIPTION
Python 3.11 exposes the native thread ID in the thread state.

However, it seems this can be out of sync/stale when a process forked in a native extension. This lead to errors such as:

```
Process 53014: ...
Python v3.11.5 (/root/.pyenv/versions/3.11.5/bin/python3.11)

Error: UNW_EBADREG: bad register number
Reason: UNW_EBADREG: bad register number
```

Upon investigation, the native thread ID (which in this case is just the PID) was still pointing to the parent process PID.

The easiest fix here is to just use the existing logic in py-spy to retrieve the thread ID from the OS. This leads to the desired result:

```
Process 53014: ...
Python v3.11.5 (...)

Thread 53014 (idle): "MainThread"
...
```

I'm not sure if this is a bug on the Python side - I can see why they wouldn't update/poll a new thread ID after a fork in a native extension - afaik there is no way for Python to tell it's been forked, and it's likely set on init. I haven't checked the CPython source for this though. I might investigate further, but since this fix resolves my problem, won't dive too deep into it.


