### PR TITLE
Add `--native-all` flag that also print the stack of non-python threads

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,7 @@ impl Config {
         #[cfg(unwind)]
             let native_all = Arg::new("native-all")
             .short('N')
-            .long("native=all")
+            .long("native-all")
             .help("Collect stack traces from native-only threads. Implies `--native`.");
 
         #[cfg(not(target_os="freebsd"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -345,6 +345,13 @@ impl Config {
         #[cfg(unwind)]
         let dump = dump.arg(native.clone());
 
+        #[cfg(unwind)]
+        let record = record.arg(native_all.clone());
+        #[cfg(unwind)]
+        let top = top.arg(native_all.clone());
+        #[cfg(unwind)]
+        let dump = dump.arg(native_all.clone());
+
         // Nonblocking isn't an option for freebsd, remove
         #[cfg(not(target_os = "freebsd"))]
         let record = record.arg(nonblocking.clone());

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,13 +165,13 @@ impl Config {
             .takes_value(true);
 
         #[cfg(unwind)]
-            let native = Arg::new("native")
+        let native = Arg::new("native")
             .short('n')
             .long("native")
             .help("Collect stack traces from native extensions written in Cython, C or C++");
 
         #[cfg(unwind)]
-            let native_all = Arg::new("native-all")
+        let native_all = Arg::new("native-all")
             .short('N')
             .long("native-all")
             .help("Collect stack traces from native-only threads. Implies `--native`.");

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -242,6 +242,10 @@ impl NativeStack {
         }
     }
 
+    pub fn add_native_only_threads(&self, process: &remoteprocess::Process, traces: &Vec<&remoteprocess::StackFrame>) {
+        todo!()
+    }
+
     /// translates a native frame into a optional frame. none indicates we should ignore this frame
     fn translate_native_frame(&self, frame: &remoteprocess::StackFrame) -> Option<Frame> {
         match &frame.function {

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -337,7 +337,7 @@ impl PythonSpy {
         #[cfg(unwind)]
         if self.config.native_all {
             if let Some(native) = self.native.as_mut() {
-                native.add_native_only_threads(&self.process, &traces);
+                native.add_native_only_threads(&self.process, &mut traces)?;
             }
         }
 

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -293,7 +293,6 @@ impl PythonSpy {
             // Merge in the native stack frames if necessary
             #[cfg(unwind)]
             {
-                println!("Got native all config {}", self.config.native_all);
                 if self.config.native {
                     if let Some(native) = self.native.as_mut() {
                         let thread_id = trace
@@ -334,6 +333,14 @@ impl PythonSpy {
                 break;
             }
         }
+
+        #[cfg(unwind)]
+        if self.config.native_all {
+            if let Some(native) = self.native.as_mut() {
+                native.add_native_only_threads(&self.process, &traces);
+            }
+        }
+
         Ok(traces)
     }
 

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -293,6 +293,7 @@ impl PythonSpy {
             // Merge in the native stack frames if necessary
             #[cfg(unwind)]
             {
+                println!("Got native all config {}", self.config.native_all);
                 if self.config.native {
                     if let Some(native) = self.native.as_mut() {
                         let thread_id = trace


### PR DESCRIPTION
Similar to pystack's `--native-all`, this PR adds a flag with the same name to also print threads that may have been spawned from native extensions (but don't have an associated python interpreter).