### PR TITLE
Fix error handling in sampler.rs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
         run: lscpu
       - name: Install VM tools
         run: |
+          sudo apt-get update -qq
           sudo apt-get install -qq -o=Dpkg::Use-Pty=0 moreutils
           sudo chronic apt-get install -qq -o=Dpkg::Use-Pty=0 vagrant virtualbox qemu libvirt-daemon-system
       - name: Set up VM

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -56,7 +56,7 @@ impl Sampler {
                     spy
                 }
                 Err(e) => {
-                    initialized_tx.send(Err(e)).unwrap_err();
+                    initialized_tx.send(Err(e)).unwrap();
                     return;
                 }
             };
@@ -308,7 +308,7 @@ impl PythonSpyThread {
                 }
                 Err(e) => {
                     warn!("Failed to profile python from process {}: {}", pid, e);
-                    initialized_tx.send(Err(e)).unwrap_err();
+                    initialized_tx.send(Err(e)).unwrap();
                     return;
                 }
             };


### PR DESCRIPTION
We were calling unwrap_err when failing to create a PythonSpy object in sampler.rs (on the result of sending the error on a channel), when we should have been calling unwrap. Fix.

See #644