### PR TITLE
Add support for UCS-2 strings 

### DIFF
--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -33,10 +33,11 @@ pub fn copy_string<T: StringObject, P: ProcessMemory>(
             Ok(chars.iter().collect())
         }
         (2, _) => {
-            // UCS2 strings aren't used internally after v3.3: https://www.python.org/dev/peps/pep-0393/
-            // TODO: however with python 2.7 they could be added with --enable-unicode=ucs2 configure flag.
-            //            or with python 3.2 --with-wide-unicode=ucs2
-            Err(format_err!("ucs2 strings aren't supported yet!"))
+            #[allow(clippy::cast_ptr_alignment)]
+            let chars = unsafe {
+                std::slice::from_raw_parts(bytes.as_ptr() as *const u16, bytes.len() / 2)
+            };
+            Ok(String::from_utf16(chars)?)
         }
         (1, true) => Ok(String::from_utf8(bytes)?),
         (1, false) => Ok(bytes.iter().map(|&b| b as char).collect()),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -230,6 +230,27 @@ fn test_unicode() {
 }
 
 #[test]
+fn test_cyrillic() {
+    #[cfg(target_os = "macos")]
+    {
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+    }
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/cyrillic.py");
+
+    let traces = runner.spy.get_stack_traces().unwrap();
+    assert_eq!(traces.len(), 1);
+    let trace = &traces[0];
+
+    assert_eq!(trace.frames[0].name, "кириллица");
+    assert_eq!(trace.frames[0].line, 4);
+
+    assert_eq!(trace.frames[1].name, "<module>");
+    assert_eq!(trace.frames[1].line, 7);
+}
+
+#[test]
 fn test_local_vars() {
     #[cfg(target_os = "macos")]
     {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -237,6 +237,13 @@ fn test_cyrillic() {
             return;
         }
     }
+
+    // Identifiers with characters outside the ASCII range are supported from Python 3
+    let runner = TestRunner::new(Config::default(), "./tests/scripts/longsleep.py");
+    if runner.spy.version.major == 2 {
+        return;
+    }
+
     let mut runner = TestRunner::new(Config::default(), "./tests/scripts/cyrillic.py");
 
     let traces = runner.spy.get_stack_traces().unwrap();

--- a/tests/scripts/cyrillic.py
+++ b/tests/scripts/cyrillic.py
@@ -1,0 +1,15 @@
+import time
+
+
+def f(seconds):
+    time.sleep(seconds)
+
+
+def кириллица(seconds):
+    f(seconds)
+
+
+if __name__ == "__main__":
+    f(3)
+    кириллица(3)
+    f(3)

--- a/tests/scripts/cyrillic.py
+++ b/tests/scripts/cyrillic.py
@@ -1,15 +1,7 @@
 import time
 
-
-def f(seconds):
+def кириллица(seconds):
     time.sleep(seconds)
 
-
-def кириллица(seconds):
-    f(seconds)
-
-
 if __name__ == "__main__":
-    f(3)
-    кириллица(3)
-    f(3)
+    кириллица(10)

--- a/tests/scripts/cyrillic.py
+++ b/tests/scripts/cyrillic.py
@@ -4,4 +4,4 @@ def кириллица(seconds):
     time.sleep(seconds)
 
 if __name__ == "__main__":
-    кириллица(10)
+    кириллица(100)


### PR DESCRIPTION
Trying to fix an issue, when py-spy would not parse a stack trace containing functions with cyrillic names.

https://github.com/benfred/py-spy/blob/4a11c44849aa2146634ceef8ee8eb43bc1e969ad/src/python_data_access.rs#L26-L31

Seems like UCS-2 strings are in use by _some_ (maybe all?) pre-built Python binaries (tested on `mcr.microsoft.com/devcontainers/rust:1-1-bullseye` Dev Container, our company's CentOS environment, as well as my local environment with Python 3.7 and 3.11 versions installed using pyenv).

If there's a function with a UCS-2 encoded name on the first recorded stack trace, py-spy just fails.

<details>
<summary>Example</summary>

```py
import time

def кириллица(seconds):
    time.sleep(seconds)

if __name__ == "__main__":
    кириллица(10)
```

Outputs (`profile.svg` will not be created in this case):

```sh
$ py-spy record -o profile.svg -- python3 tests/scripts/cyrillic.py 
Error: Failed to find a python interpreter in the .data section
```
</details>

If py-spy successfully started the recorder, we'll get a flamegraph built without stack traces with UCS-2 strings, so final data/graph will look strange or even misleading.

<details>
<summary>Example</summary>

```py
import time

def function1(seconds):
    time.sleep(seconds)

def кириллица(seconds):
    time.sleep(seconds)

if __name__ == "__main__":
    function1(10)
    кириллица(10)
```

Outputs (`profile.svg` will be created):

```sh
$ py-spy record -o profile.svg -- python3 tests/scripts/cyrillic.py 
py-spy> Sampling process 100 times a second. Press Control-C to exit.


py-spy> Stopped sampling because process exited
py-spy> Wrote flamegraph data to 'profile.svg'. Samples: 12 Errors: 1025
```
</details>
