### PR TITLE
Added support for s390x wheel package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,48 @@ jobs:
         name: wheels
         path: dist
 
+  build-linux-s390x:
+    runs-on: ubuntu-latest
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ['s390x']
+    steps:
+    - name: Building package on ${{ matrix.platform }}
+      uses: appleboy/ssh-action@v0.1.10
+      env:
+        GH_REPOSITORY: ${{ github.server_url }}/${{ github.repository }}
+      with:
+        host: ${{secrets.S390X_SSH_HOST}}
+        username: ${{secrets.S390X_SSH_USER }}
+        key: ${{secrets.S390X_SSH_KEY}}
+        envs: GH_REPOSITORY
+        script: |
+          git clone ${GH_REPOSITORY} 
+          cd py-spy
+          python3 -m build
+
+    - name: Extracting wheel package from remote s390x instance to runner os
+      env:
+        S390X_SSH_HOST: ${{ secrets.S390X_SSH_HOST }}
+        S390X_SSH_KEY: ${{ secrets.S390X_SSH_KEY }}
+        S390X_SSH_USER: ${{secrets.S390X_SSH_USER }}
+      run: |
+        mkdir ~/.ssh
+        chmod 700 ~/.ssh
+        touch ~/.ssh/id_builder_s390x
+        chmod 600 ~/.ssh/id_builder_s390x
+        echo "$S390X_SSH_KEY" > ~/.ssh/id_builder_s390x
+        scp -i ~/.ssh/id_builder_s390x -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r $S390X_SSH_USER@$S390X_SSH_HOST:~/py-spy . 
+        ssh -tt -i ~/.ssh/id_builder_s390x -o "StrictHostKeyChecking no" $S390X_SSH_USER@$S390X_SSH_HOST "rm -rf ~/py-spy"
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: py-spy/dist
+
   build-freebsd:
     runs-on: ubuntu-22.04
     needs: [lint]

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -245,7 +245,8 @@ pub mod pyruntime {
         any(
             target_arch = "powerpc64",
             target_arch = "powerpc",
-            target_arch = "mips"
+            target_arch = "mips",
+            target_arch = "s390x"
         )
     ))]
     pub fn get_tstate_current_offset(version: &Version) -> Option<usize> {


### PR DESCRIPTION
Modified mod.rs for s390x
Created workflow for generating wheel package for s390x:
  -  We created a RHEL instance on s390x in a remote server
  - Clone repository in remote server
  - Build the wheel package in the remote server
  - Fetched wheel package from the remote server to runner os
  - Provided upload wheel step for fetched wheel package
