### PR TITLE
(win, python >= 3.10) Fix symbol address resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 [[package]]
 name = "remoteprocess"
 version = "0.4.13"
-source = "git+https://github.com/akhramov/remoteprocess?branch=feature/windows-aarch64#4b7cfbf55816a94a81e3e433fbaea4ad21b4d9c8"
+source = "git+https://github.com/akhramov/remoteprocess?branch=feature/windows-aarch64#e19a74e004d01810e53cdf4fafd9c4c9fe1b623d"
 dependencies = [
  "addr2line",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
@@ -139,26 +139,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
@@ -206,9 +186,9 @@ checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -434,6 +414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,17 +457,6 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
@@ -498,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -534,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
@@ -547,17 +527,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "goblin"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
 
 [[package]]
 name = "goblin"
@@ -780,23 +749,12 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libproc"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
-dependencies = [
- "bindgen 0.64.0",
- "errno 0.2.8",
- "libc",
-]
-
-[[package]]
-name = "libproc"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229004ebba9d1d5caf41623f1523b6d52abb47d9f6ab87f7e6fc992e3b854aef"
 dependencies = [
- "bindgen 0.68.1",
- "errno 0.3.1",
+ "bindgen",
+ "errno",
  "libc",
 ]
 
@@ -945,9 +903,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "flate2",
  "memchr",
@@ -1053,9 +1011,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec8fdc22cb95c02f6a26a91fb1cd60a7a115916c2ed3b09d0a312e11785bd57"
 dependencies = [
  "anyhow",
- "bindgen 0.68.1",
+ "bindgen",
  "libc",
- "libproc 0.14.2",
+ "libproc",
  "mach2",
  "winapi",
 ]
@@ -1065,6 +1023,7 @@ name = "py-spy"
 version = "0.3.14"
 dependencies = [
  "anyhow",
+ "cfg-if",
  "chrono",
  "clap 3.2.25",
  "clap_complete",
@@ -1072,7 +1031,7 @@ dependencies = [
  "cpp_demangle",
  "ctrlc",
  "env_logger",
- "goblin 0.7.1",
+ "goblin",
  "indicatif",
  "inferno",
  "lazy_static",
@@ -1198,15 +1157,15 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "remoteprocess"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91114d769bd6dffc9565c01bbba121ca223efba7fdbc4c57b63fd91c1ea8478e"
+version = "0.4.13"
+source = "git+https://github.com/akhramov/remoteprocess?branch=feature/windows-aarch64#4b7cfbf55816a94a81e3e433fbaea4ad21b4d9c8"
 dependencies = [
  "addr2line",
- "goblin 0.6.1",
+ "cfg-if",
+ "goblin",
  "lazy_static",
  "libc",
- "libproc 0.13.0",
+ "libproc",
  "log",
  "mach",
  "mach_o_sys",
@@ -1247,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.3.1",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
@@ -1256,12 +1215,12 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "thiserror",
+ "derive_more",
  "twox-hash",
 ]
 
@@ -1432,26 +1391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
  "terminal_size",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.8"
 rand_distr = "0.4"
-remoteprocess = {version="0.4.12", features=["unwind"]}
+remoteprocess = { git = "https://github.com/akhramov/remoteprocess", branch = "feature/windows-aarch64", features = ["unwind"] }
 chrono = "0.4.26"
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 py-spy-testdata = "0.1.0"

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use goblin::Object;
 use memmap::Mmap;
 
+#[allow(dead_code)]
 pub struct BinaryInfo {
     pub filename: std::path::PathBuf,
     pub symbols: HashMap<String, u64>,

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -149,9 +149,7 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
         Object::PE(pe) => {
             for export in pe.exports {
                 if let Some(name) = export.name {
-                    if let Some(export_offset) = export.offset {
-                        symbols.insert(name.to_string(), export_offset as u64 + offset);
-                    }
+                    symbols.insert(name.to_string(), export.rva as u64 + offset);
                 }
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -422,7 +422,7 @@ impl Config {
         }
 
         config.subprocesses = matches.occurrences_of("subprocesses") > 0;
-        config.command = subcommand.to_owned();
+        subcommand.clone_into(&mut config.command);
 
         // options that can be shared between subcommands
         config.pid = matches

--- a/src/cython.rs
+++ b/src/cython.rs
@@ -34,7 +34,7 @@ impl SourceMaps {
         if let Some(map) = self.maps.get(&frame.filename) {
             if let Some(map) = map {
                 if let Some((file, line)) = map.lookup(line) {
-                    frame.filename = file.clone();
+                    frame.filename.clone_from(file);
                     frame.line = *line as i32;
                 }
             }

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -613,7 +613,7 @@ pub trait ContainsAddr {
 
 impl ContainsAddr for Vec<MapRange> {
     #[cfg(windows)]
-    fn contains_addr(&self, addr: usize) -> bool {
+    fn contains_addr(&self, _addr: usize) -> bool {
         // On windows, we can't just check if a pointer is valid by looking to see if it points
         // to something in the virtual memory map. Brute-force it instead
         true

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -136,7 +136,17 @@ impl PythonProcessInfo {
             let libmap = maps.iter().find(|m| {
                 if let Some(pathname) = m.filename() {
                     if let Some(pathname) = pathname.to_str() {
-                        return is_python_lib(pathname) && m.is_exec();
+                        cfg_if::cfg_if! {
+                            if #[cfg(windows)] {
+                                // On windows we use utilize RVA (relative
+                                // virtual addresses), so we need to know just
+                                // the base address.
+                                return is_python_lib(pathname);
+                            } else {
+                                return is_python_lib(pathname) && m.is_exec();
+                            }
+
+                        };
                     }
                 }
                 false

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -1,5 +1,3 @@
-#[cfg(windows)]
-use regex::RegexBuilder;
 use std::collections::HashMap;
 #[cfg(all(target_os = "linux", unwind))]
 use std::collections::HashSet;
@@ -26,6 +24,7 @@ use crate::stack_trace::{get_gil_threadid, get_stack_trace, StackTrace};
 use crate::version::Version;
 
 /// Lets you retrieve stack traces of a running python program
+#[allow(dead_code)]
 pub struct PythonSpy {
     pub pid: Pid,
     pub process: Process,

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -219,7 +219,7 @@ impl Sampler {
                     let process = process_info
                         .entry(pid)
                         .or_insert_with(|| get_process_info(pid, &spies).map(|p| Arc::new(*p)));
-                    trace.process_info = process.clone();
+                    trace.process_info.clone_from(process);
                 }
 
                 // Send the collected info back


### PR DESCRIPTION
For PE images we use file offsets to calculate symbol addresses in memory. However PE loader uses RVAs (relative virtual addresses) instead, so the current approach breaks for newer python releases.

This change tweaks windows symbol address resolution to rely on RVAs instead of file offsets.