### PR TITLE
Enabled ppc64le arch on CI and fixed lint & build issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,9 +95,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [i686-musl, armv7-musleabihf, aarch64-musl, x86_64-musl]
+        target: [i686-musl, armv7-musleabihf, aarch64-musl, x86_64-musl, powerpc64le-musl]
     container:
-      image: docker://benfred/rust-musl-cross:${{ matrix.target }}
+      image: docker://${{ matrix.target == 'powerpc64le-musl' && 'messense' || 'benfred'}}/rust-musl-cross:${{ matrix.target }}
       env:
         RUSTUP_HOME: /root/.rustup
         CARGO_HOME: /root/.cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,14 +25,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1747,3 +1748,23 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ termios = "0.3.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv" ]}
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(unwind)'] }

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use goblin::Object;
 use memmap::Mmap;
 
+#[allow(dead_code)]
 pub struct BinaryInfo {
     pub filename: std::path::PathBuf,
     pub symbols: HashMap<String, u64>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -422,7 +422,7 @@ impl Config {
         }
 
         config.subprocesses = matches.occurrences_of("subprocesses") > 0;
-        config.command = subcommand.to_owned();
+        subcommand.clone_into(&mut config.command);
 
         // options that can be shared between subcommands
         config.pid = matches

--- a/src/cython.rs
+++ b/src/cython.rs
@@ -34,7 +34,7 @@ impl SourceMaps {
         if let Some(map) = self.maps.get(&frame.filename) {
             if let Some(map) = map {
                 if let Some((file, line)) = map.lookup(line) {
-                    frame.filename = file.clone();
+                    frame.filename.clone_from(file);
                     frame.line = *line as i32;
                 }
             }

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -248,7 +248,7 @@ pub mod pyruntime {
             target_arch = "mips"
         )
     ))]
-    pub fn get_tstate_current_offset(version: &Version) -> Option<usize> {
+    pub fn get_tstate_current_offset(_version: &Version) -> Option<usize> {
         None
     }
 

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -26,6 +26,7 @@ use crate::stack_trace::{get_gil_threadid, get_stack_trace, StackTrace};
 use crate::version::Version;
 
 /// Lets you retrieve stack traces of a running python program
+#[allow(dead_code)]
 pub struct PythonSpy {
     pub pid: Pid,
     pub process: Process,

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -219,7 +219,7 @@ impl Sampler {
                     let process = process_info
                         .entry(pid)
                         .or_insert_with(|| get_process_info(pid, &spies).map(|p| Arc::new(*p)));
-                    trace.process_info = process.clone();
+                    trace.process_info.clone_from(process);
                 }
 
                 // Send the collected info back


### PR DESCRIPTION
1. Enabled ppc64le arch on CI by using powerpc64le-musl image
2. Fixed lint & build issues which were occurring on latest master branch while building on CI