### PR TITLE
Fix bug introduced by commit 5820bf6a7ef56718284add709bc56cc7b8cb6c16

### DIFF
--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -10,6 +10,10 @@ pub struct BinaryInfo {
     pub symbols: HashMap<String, u64>,
     pub bss_addr: u64,
     pub bss_size: u64,
+    #[allow(dead_code)]
+    pub addr: u64,
+    #[allow(dead_code)]
+    pub size: u64,
 }
 
 impl BinaryInfo {
@@ -20,7 +24,7 @@ impl BinaryInfo {
 }
 
 /// Uses goblin to parse a binary file, returns information on symbols/bss/adjusted offset etc
-pub fn parse_binary(filename: &Path, addr: u64) -> Result<BinaryInfo, Error> {
+pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo, Error> {
     let offset = addr;
 
     let mut symbols = HashMap::new();
@@ -78,6 +82,8 @@ pub fn parse_binary(filename: &Path, addr: u64) -> Result<BinaryInfo, Error> {
                 symbols,
                 bss_addr,
                 bss_size,
+                addr,
+                size,
             })
         }
 
@@ -132,6 +138,8 @@ pub fn parse_binary(filename: &Path, addr: u64) -> Result<BinaryInfo, Error> {
                 symbols,
                 bss_addr: bss_header.sh_addr + offset,
                 bss_size: bss_header.sh_size,
+                addr,
+                size,
             })
         }
         Object::PE(pe) => {
@@ -160,6 +168,8 @@ pub fn parse_binary(filename: &Path, addr: u64) -> Result<BinaryInfo, Error> {
                         symbols,
                         bss_addr,
                         bss_size,
+                        addr,
+                        size,
                     }
                 })
         }

--- a/src/coredump.rs
+++ b/src/coredump.rs
@@ -191,7 +191,7 @@ impl PythonCoreDump {
                 .find(|m| m.filename().is_some() & m.is_exec())
                 .ok_or_else(|| format_err!("Failed to get binary from coredump"))?;
             let python_filename = map.filename().unwrap();
-            let python_binary = parse_binary(python_filename, map.start() as _);
+            let python_binary = parse_binary(python_filename, map.start() as _, map.size() as _);
             info!("Found python binary @ {}", python_filename.display());
             (python_filename.to_owned(), python_binary)
         };
@@ -211,7 +211,8 @@ impl PythonCoreDump {
             if let Some(libpython) = libmap {
                 if let Some(filename) = &libpython.filename() {
                     info!("Found libpython binary @ {}", filename.display());
-                    let parsed = parse_binary(filename, libpython.start() as u64)?;
+                    let parsed =
+                        parse_binary(filename, libpython.start() as u64, libpython.size() as u64)?;
                     libpython_binary = Some(parsed);
                 }
             }

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -102,7 +102,7 @@ impl PythonProcessInfo {
             let filename = std::path::PathBuf::from(format!("/proc/{}/exe", process.pid));
 
             // TODO: consistent types? u64 -> usize? for map.start etc
-            let python_binary = parse_binary(&filename, map.start() as u64);
+            let python_binary = parse_binary(&filename, map.start() as u64, map.size() as u64);
 
             // windows symbols are stored in separate files (.pdb), load
             #[cfg(windows)]
@@ -158,7 +158,8 @@ impl PythonProcessInfo {
                     ));
 
                     #[allow(unused_mut)]
-                    let mut parsed = parse_binary(filename, libpython.start() as u64)?;
+                    let mut parsed =
+                        parse_binary(filename, libpython.start() as u64, libpython.size() as u64)?;
                     #[cfg(windows)]
                     parsed.symbols.extend(get_windows_python_symbols(
                         process.pid,
@@ -204,8 +205,11 @@ impl PythonProcessInfo {
                             libpython.filename.display()
                         );
 
-                        let mut binary =
-                            parse_binary(&libpython.filename, libpython.segment.vmaddr)?;
+                        let mut binary = parse_binary(
+                            &libpython.filename,
+                            libpython.segment.vmaddr,
+                            libpython.segment.vmsize,
+                        )?;
 
                         // TODO: bss addr offsets returned from parsing binary are wrong
                         // (assumes data section isn't split from text section like done here).


### PR DESCRIPTION
Commit 5820bf6a7ef56718284add709bc56cc7b8cb6c16 removes field `addr` and `size` from BinaryInfo, which are used when feature `unwind` is enabled. So recover these two fields.

Fix building error:
cargo build --all-features
error[E0609]: no field `addr` on type `&BinaryInfo`
  --> src/binary_parser.rs:18:22
   |
18 |         addr >= self.addr && addr < (self.addr + self.size)
   |                      ^^^^ unknown field
   |
   = note: available fields are: `symbols`, `bss_addr`, `bss_size`

error[E0609]: no field `addr` on type `&BinaryInfo`
  --> src/binary_parser.rs:18:43
   |
18 |         addr >= self.addr && addr < (self.addr + self.size)
   |                                           ^^^^ unknown field
   |
   = note: available fields are: `symbols`, `bss_addr`, `bss_size`

error[E0609]: no field `size` on type `&BinaryInfo`
  --> src/binary_parser.rs:18:55
   |
18 |         addr >= self.addr && addr < (self.addr + self.size)
   |                                                       ^^^^ unknown field
   |
   = note: available fields are: `symbols`, `bss_addr`, `bss_size`