### PR TITLE
[Speedscope] Remove col field

### DIFF
--- a/src/speedscope.rs
+++ b/src/speedscope.rs
@@ -99,7 +99,8 @@ struct Frame {
     name: String,
     file: Option<String>,
     line: Option<u32>,
-    col: Option<u32>,
+    // col is optional, and not written by py-spy
+    // col: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -185,7 +186,6 @@ impl Frame {
             } else {
                 None
             },
-            col: None,
         }
     }
 }


### PR DESCRIPTION
I noticed the generated json has a lot of col: null, and that py-spy doesn't ever write this. This field isn't needed in the output, so this can reduce the file size. 

I'm open to suggestions on whether the commented out code should be there, I think it's useful to know that this field does exist. If the col is optionally written in the future, we can add `#[serde(skip_serializing_if = "Option::is_none")]` to it, but adding that now introduces an unnecessary branch.