### PR TITLE
Fix corruption when running cargo test on ARM64

### DIFF
--- a/src/coredump.rs
+++ b/src/coredump.rs
@@ -429,12 +429,12 @@ mod elfcore {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 #[cfg(test)]
 mod test {
     use super::*;
     use py_spy_testdata::get_coredump_path;
 
-    #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_coredump() {
         // we won't have the python binary for the core dump here,


### PR DESCRIPTION
Run `cargo test` on ARM64 will encounter following corruption, which is caused by unaligned memory access. So enable the test for x86_64 only.

thread 'coredump::test::test_coredump' panicked at src/coredump.rs:94:30: misaligned pointer dereference: address must be a multiple of 0x8 but is 0xffffa6ba0334 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `/dragonball/py-spy.git/target/debug/deps/py_spy-1a1c8047c3d9ee13` (signal: 6, SIGABRT: process abort signal)