### PR TITLE
Add custom error message for use of `--native` on unsupported platforms

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -160,11 +160,15 @@ impl Config {
             .help("PID of a running python program to spy on")
             .takes_value(true);
 
-        #[cfg(feature = "unwind")]
-        let native = Arg::new("native")
+        let mut native = Arg::new("native")
             .short('n')
             .long("native")
             .help("Collect stack traces from native extensions written in Cython, C or C++");
+
+        // Only show `--native` on platforms where it's supported
+        if !cfg!(feature = "unwind") {
+            native = native.hide(true);
+        }
 
         #[cfg(not(target_os="freebsd"))]
         let nonblocking = Arg::new("nonblocking")
@@ -327,12 +331,8 @@ impl Config {
                     .help("Shell type"),
             );
 
-        // add native unwinding if appropriate
-        #[cfg(feature = "unwind")]
         let record = record.arg(native.clone());
-        #[cfg(feature = "unwind")]
         let top = top.arg(native.clone());
-        #[cfg(feature = "unwind")]
         let dump = dump.arg(native.clone());
 
         // Nonblocking isn't an option for freebsd, remove
@@ -360,6 +360,14 @@ impl Config {
         let mut config = Config::default();
 
         let (subcommand, matches) = matches.subcommand().unwrap();
+
+        // Check if `--native` was used on an unsupported platform
+        if !cfg!(feature = "unwind") && matches.contains_id("native") {
+            eprintln!(
+                "Collecting stack traces from native extensions (`--native`) is not supported on your platform."
+            );
+            std::process::exit(1);
+        }
 
         match subcommand {
             "record" => {


### PR DESCRIPTION
e.g.,

```
❯ cargo run -q -- record --native --pid 123
Collecting stack traces from native extensions (`--native`) is not supported on your platform.
```

instead of "unrecognized flag"

Closes https://github.com/benfred/py-spy/issues/646 — attempting to address the confusion here.