### PR TITLE
Enhance the way to demangle rust symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "rand_distr",
  "regex",
  "remoteprocess",
+ "rustc-demangle",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "1.0"
 rand = "0.8"
 rand_distr = "0.4"
 remoteprocess = {version="0.5.0", features=["unwind"]}
+rustc-demangle = "0.1.24"
 chrono = "0.4.26"
 
 [dev-dependencies]

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -273,7 +273,13 @@ impl NativeStack {
                 if func.starts_with('_') {
                     if let Ok((sym, _)) = BorrowedSymbol::with_tail(func.as_bytes()) {
                         let options = DemangleOptions::new().no_params().no_return_type();
-                        if let Ok(sym) = sym.demangle(&options) {
+                        if let Ok(mut sym) = sym.demangle(&options) {
+                            // try to demangle with rustc_demangle for better representation for Rust symbols
+                            if let Ok(sym2) = rustc_demangle::try_demangle(func) {
+                                if sym2.as_str().len() < sym.len() {
+                                    sym = sym2.to_string();
+                                }
+                            }
                             demangled = Some(sym);
                         }
                     }


### PR DESCRIPTION
Try to demangle with both cpp_demange and rustc_demange, and choose the shorter one.