### PR TITLE
Bump FreeBSD Rust toolchain from 1.73.0 to 1.80.1

### DIFF
--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
     chsh -s /usr/local/bin/bash vagrant
     pw groupmod wheel -m vagrant
     su -l vagrant <<'EOF'
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.73.0
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.80.1
     EOF
   SHELL
 end


### PR DESCRIPTION
Should unblock the failure in #704 ([job](https://github.com/benfred/py-spy/actions/runs/11370507698/job/31630499099?pr=704))