### PR TITLE
Detect GIL on python 3.12

### DIFF
--- a/src/coredump.rs
+++ b/src/coredump.rs
@@ -246,7 +246,8 @@ impl PythonCoreDump {
 
         // lets us figure out which thread has the GIL
         let config = Config::default();
-        let threadstate_address = get_threadstate_address(&python_info, &version, &config)?;
+        let threadstate_address =
+            get_threadstate_address(interpreter_address, &python_info, &version, &config)?;
         info!("found threadstate at 0x{:016x}", threadstate_address);
 
         Ok(PythonCoreDump {

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -529,6 +529,7 @@ where
 }
 
 pub fn get_threadstate_address(
+    interpreter_address: usize,
     python_info: &PythonProcessInfo,
     version: &Version,
     config: &Config,
@@ -536,7 +537,16 @@ pub fn get_threadstate_address(
     let threadstate_address = match version {
         Version {
             major: 3,
-            minor: 7..=12,
+            minor: 12,
+            ..
+        } => {
+            let interp: v3_12_0::_is = Default::default();
+            let offset = crate::utils::offset_of(&interp, &interp._gil.last_holder._value);
+            interpreter_address + offset
+        }
+        Version {
+            major: 3,
+            minor: 7..=11,
             ..
         } => match python_info.get_symbol("_PyRuntime") {
             Some(&addr) => {

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -77,7 +77,11 @@ where
     I: InterpreterState,
     P: ProcessMemory,
 {
-    let gil_thread_id = get_gil_threadid::<I, P>(threadstate_address, process)?;
+    let gil_thread_id = if interpreter.gil_locked().unwrap_or(true) {
+        get_gil_threadid::<I, P>(threadstate_address, process)?
+    } else {
+        0
+    };
 
     let mut ret = Vec::new();
     let mut threads = interpreter.head();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,3 +20,7 @@ pub fn resolve_filename(filename: &str, modulename: &str) -> Option<String> {
 
     None
 }
+
+pub fn offset_of<T, M>(object: *const T, member: *const M) -> usize {
+    member as usize - object as usize
+}


### PR DESCRIPTION
Use the InterpreterState._gil member to figure out both if the gil is locked, and if so which thread is holding the GIL

closes #692