### PR TITLE
Fix profiling when python symbols aren't available.

### DIFF
--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -12,6 +12,8 @@ pub struct BinaryInfo {
     pub symbols: HashMap<String, u64>,
     pub bss_addr: u64,
     pub bss_size: u64,
+    pub pyruntime_addr: u64,
+    pub pyruntime_size: u64,
     #[allow(dead_code)]
     pub addr: u64,
     #[allow(dead_code)]
@@ -65,11 +67,23 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                 }
             };
 
+            let mut pyruntime_addr = 0;
+            let mut pyruntime_size = 0;
             let mut bss_addr = 0;
             let mut bss_size = 0;
             for segment in mach.segments.iter() {
                 for (section, _) in &segment.sections()? {
-                    if section.name()? == "__bss" {
+                    let name = section.name()?;
+                    if name == "PyRuntime" {
+                        if let Some(addr) = section.addr.checked_add(offset) {
+                            if addr.checked_add(section.size).is_some() {
+                                pyruntime_addr = addr;
+                                pyruntime_size = section.size;
+                            }
+                        }
+                    }
+
+                    if name == "__bss" {
                         if let Some(addr) = section.addr.checked_add(offset) {
                             if addr.checked_add(section.size).is_some() {
                                 bss_addr = addr;
@@ -94,6 +108,8 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                 symbols,
                 bss_addr,
                 bss_size,
+                pyruntime_addr,
+                pyruntime_size,
                 addr,
                 size,
             })
@@ -153,6 +169,21 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                 bss_end = bss_header.sh_addr + bss_header.sh_size;
             }
 
+            let pyruntime_header = elf.section_headers.iter().find(|header| {
+                strtab
+                    .get_at(header.sh_name)
+                    .map_or(false, |name| name == ".PyRuntime")
+            });
+
+            let mut pyruntime_addr = 0;
+            let mut pyruntime_size = 0;
+            if let Some(header) = pyruntime_header {
+                if let Some(addr) = header.sh_addr.checked_add(offset) {
+                    pyruntime_addr = addr;
+                    pyruntime_size = header.sh_size;
+                }
+            }
+
             for sym in elf.syms.iter() {
                 // Skip imported symbols
                 if sym.is_import()
@@ -194,6 +225,8 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                 symbols,
                 bss_addr,
                 bss_size,
+                pyruntime_addr,
+                pyruntime_size,
                 addr,
                 size,
             })
@@ -209,33 +242,48 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                 }
             }
 
-            pe.sections
-                .iter()
-                .find(|section| section.name.starts_with(b".data"))
-                .ok_or_else(|| {
-                    format_err!(
-                        "Failed to find .data section in PE binary of {}",
-                        filename.display()
-                    )
-                })
-                .map(|data_section| {
-                    let mut bss_addr = 0;
-                    let mut bss_size = 0;
-                    if let Some(addr) = offset.checked_add(data_section.virtual_address as u64) {
-                        if addr.checked_add(data_section.virtual_size as u64).is_some() {
+            let mut bss_addr = 0;
+            let mut bss_size = 0;
+            let mut pyruntime_addr = 0;
+            let mut pyruntime_size = 0;
+            let mut found_data = false;
+            for section in pe.sections.iter() {
+                if section.name.starts_with(b".data") {
+                    found_data = true;
+                    if let Some(addr) = offset.checked_add(section.virtual_address as u64) {
+                        if addr.checked_add(section.virtual_size as u64).is_some() {
                             bss_addr = addr;
-                            bss_size = u64::from(data_section.virtual_size);
+                            bss_size = u64::from(section.virtual_size);
                         }
                     }
-
-                    BinaryInfo {
-                        symbols,
-                        bss_addr,
-                        bss_size,
-                        addr,
-                        size,
+                } else if section.name.starts_with(b"PyRuntim") {
+                    // note that the name is only 8 chars here, so we don't check for
+                    // trailing 'e' in PyRuntime
+                    if let Some(addr) = offset.checked_add(section.virtual_address as u64) {
+                        if addr.checked_add(section.virtual_size as u64).is_some() {
+                            pyruntime_addr = addr;
+                            pyruntime_size = u64::from(section.virtual_size);
+                        }
                     }
-                })
+                }
+            }
+
+            if !found_data {
+                return Err(format_err!(
+                    "Failed to find .data section in PE binary of {}",
+                    filename.display()
+                ));
+            }
+
+            Ok(BinaryInfo {
+                symbols,
+                bss_addr,
+                bss_size,
+                pyruntime_size,
+                pyruntime_addr,
+                addr,
+                size,
+            })
         }
         _ => Err(format_err!("Unhandled binary type")),
     }


### PR DESCRIPTION
Since python 3.10 - we haven't been able to profile python interpreters that have been compiled without symbols. This is because cpython changed where the 'PyRuntime' global is stored in python 3.10, from being in the BSS section into being in its own named section in the binary (https://github.com/python/cpython/pull/4802)

This especially affected profiling on windows, where you'd have to install python symbols to be able to use py-spy.

Fix by reading in the address/size of the the PyRuntime section from the elf/mach/pe binaries and using that to scan python interpreters when symbols aren't available.