### PR TITLE
Fix macOS version identification and improve multiple-section support

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -13,7 +13,7 @@ pub struct Version {
 }
 
 impl Version {
-    pub fn scan_bytes(data: &[u8]) -> Result<Version, Error> {
+    pub fn scan_bytes(data: &[u8]) -> Result<Option<Version>, Error> {
         lazy_static! {
             static ref RE: Regex = Regex::new(
                 r"((2|3)\.(3|4|5|6|7|8|9|10|11|12|13)\.(\d{1,2}))((a|b|c|rc)\d{1,2})?(\+(?:[0-9a-z-]+(?:[.][0-9a-z-]+)*)?)? (.{1,64})"
@@ -48,15 +48,15 @@ impl Version {
                 }
             }
 
-            return Ok(Version {
+            return Ok(Some(Version {
                 major,
                 minor,
                 patch,
                 release_flags: release.to_owned(),
                 build_metadata,
-            });
+            }));
         }
-        Err(format_err!("failed to find version string"))
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
Fixes #726, probably.

This could use some testing.

On some builds of Python on macOS, such as my Homebrew build of Python 3.13, the version ends up in the section `__DATA,__common` instead of `__DATA,__bss`.  This difference appears to be caused by the use of ThinLTO.  I'm not sure exactly why LLVM does that, but for py-spy's purposes, it suffices to scan both sections.

Implement this by having `Binary` store a `Vec` of `(addr, size)` pairs instead of just one `bss_addr` and `bss_size`.

While I'm at it:

- Put the pyruntime section bounds into the same `Vec` rather than keeping it as a separate set of fields.  This was already treated like another bss section.

- Change all three executable-format parsing routines so that duplicate sections all go into the `Vec`, instead of them having to pick one BSS section.

- Since we are now scanning more sections, there will be more harmless "didn't find anything" errors.  Therefore, differentiate the cases by changing the return type of `Version::scan_bytes` from `Result<X, Error>` to `Result<Option<X>, Error>`. "Didn't find anything" now results in `Ok(None)`, which the callers silently ignore, but the callers `warn!` on all other errors.

- Improve error handling of `check_interpreter_address` along similar lines.  It now returns an iterator of `Result`s, which leaves it to the caller to decide how to expose the error from each individual address.  The callers expose them either as `warn!` (if `_PyRuntime` was found and we really expect this address to be valid) or just `debug!` (if we're brute-forcing addresses).

  Maybe this one was overkill... In brute-force mode, it does waste time formatting errors that will never be shown most of the time, but in practice this shouldn't have noticeable impact: the number of addresses being brute-forced isn't _that_ large.