### PR TITLE
Check "version", new name of "Py_GetVersion.version" since 3.12

### DIFF
--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -286,7 +286,10 @@ where
     P: ProcessMemory,
 {
     // If possible, grab the sys.version string from the processes memory (mac osx).
-    if let Some(&addr) = python_info.get_symbol("Py_GetVersion.version") {
+    if let Some(&addr) = python_info
+        .get_symbol("Py_GetVersion.version")
+        .or_else(|| python_info.get_symbol("version"))
+    {
         info!("Getting version from symbol address");
         if let Ok(bytes) = process.copy(addr as usize, 128) {
             if let Ok(version) = Version::scan_bytes(&bytes) {


### PR DESCRIPTION
Check "version", new name of "Py_GetVersion.version" since 3.12

https://github.com/python/cpython/commit/3c57971a2d3b6d2c6fd1f525ba2108fccb35add2

Fixes #726