### PR TITLE
Add feature to periodically save profile

### DIFF
--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -104,7 +104,7 @@ impl Chrometrace {
         Ok(())
     }
 
-    pub fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
+    pub fn write<T: Write + ?Sized>(&self, w: &mut T) -> Result<(), Error> {
         let mut events = Vec::new();
         events.extend(self.events.to_vec());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct Config {
     #[doc(hidden)]
     pub sampling_rate: u64,
     #[doc(hidden)]
+    pub save_period: Option<u64>,
+    #[doc(hidden)]
     pub filename: Option<String>,
     #[doc(hidden)]
     pub format: Option<FileFormat>,
@@ -125,6 +127,7 @@ impl Default for Config {
             blocking: LockingStrategy::Lock,
             show_line_numbers: false,
             sampling_rate: 100,
+            save_period: None,
             duration: RecordDuration::Unlimited,
             native: false,
             gil_only: false,
@@ -249,6 +252,14 @@ impl Config {
                     .takes_value(true),
             )
             .arg(rate.clone())
+            .arg(
+                Arg::new("save_period")
+                .long("save_period")
+                .value_name("save_period")
+                .value_parser(value_parser!(u64))
+                .help("The number of intervals between saving the profile to disk")
+                .takes_value(true)
+            )
             .arg(subprocesses.clone())
             .arg(Arg::new("function").short('F').long("function").help(
                 "Aggregate samples by function's first line number, instead of current line number",
@@ -372,6 +383,7 @@ impl Config {
         match subcommand {
             "record" => {
                 config.sampling_rate = matches.value_of_t("rate")?;
+                config.save_period = matches.get_one::<u64>("save_period").cloned();
                 config.duration = match matches.value_of("duration") {
                     Some("unlimited") | None => RecordDuration::Unlimited,
                     Some(seconds) => {

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -80,7 +80,7 @@ impl Flamegraph {
             .collect()
     }
 
-    pub fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
+    pub fn write<T: Write + ?Sized>(&self, w: &mut T) -> Result<(), Error> {
         let mut opts = Options::default();
         opts.direction = Direction::Inverted;
         opts.min_width = 0.1;
@@ -92,7 +92,7 @@ impl Flamegraph {
         Ok(())
     }
 
-    pub fn write_raw(&self, w: &mut dyn Write) -> Result<(), Error> {
+    pub fn write_raw<T: Write + ?Sized>(&self, w: &mut T) -> Result<(), Error> {
         for line in self.get_lines() {
             w.write_all(line.as_bytes())?;
             w.write_all(b"\n")?;

--- a/src/speedscope.rs
+++ b/src/speedscope.rs
@@ -253,7 +253,7 @@ impl Stats {
         Ok(())
     }
 
-    pub fn write(&self, w: &mut dyn Write) -> Result<(), Error> {
+    pub fn write<T: Write + ?Sized>(&self, w: &mut T) -> Result<(), Error> {
         let json = serde_json::to_string(&SpeedscopeFile::new(
             &self.samples,
             &self.frames,


### PR DESCRIPTION
Adding an argument to `record` subcommand to periodically update and save profile files during a py-spy session.
Added a corresponding integration test.