### PR TITLE
Fix native stack merging for Python 3.12/3.13

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,7 @@ fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error>
                     line: 0,
                     locals: None,
                     is_entry: true,
-                    last_was_shim: true,
+                    is_shim_entry: true,
                 });
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,6 +285,7 @@ fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error>
                     line: 0,
                     locals: None,
                     is_entry: true,
+                    last_was_shim: true,
                 });
             }
 

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -11,6 +11,7 @@ use crate::binary_parser::BinaryInfo;
 use crate::cython;
 use crate::stack_trace::Frame;
 use crate::utils::resolve_filename;
+use crate::version::Version;
 
 pub struct NativeStack {
     should_reload: bool,
@@ -53,6 +54,7 @@ impl NativeStack {
         &mut self,
         frames: &Vec<Frame>,
         thread: &remoteprocess::Thread,
+        version: &Version,
     ) -> Result<Vec<Frame>, Error> {
         if self.should_reload {
             self.symbolicator.reload()?;
@@ -63,12 +65,13 @@ impl NativeStack {
         let native_stack = self.get_thread(thread)?;
 
         // TODO: merging the two stack together could happen outside of thread lock
-        self.merge_native_stack(frames, native_stack)
+        self.merge_native_stack(frames, native_stack, version)
     }
     pub fn merge_native_stack(
         &mut self,
         frames: &Vec<Frame>,
         native_stack: Vec<u64>,
+        version: &Version,
     ) -> Result<Vec<Frame>, Error> {
         let mut python_frame_index = 0;
         let mut merged = Vec::new();
@@ -98,7 +101,19 @@ impl NativeStack {
                         while python_frame_index < frames.len() {
                             merged.push(frames[python_frame_index].clone());
 
-                            if frames[python_frame_index].is_entry {
+                            if match version {
+                                Version {
+                                    major: 3,
+                                    minor: 11,
+                                    ..
+                                } => frames[python_frame_index].is_entry,
+                                Version {
+                                    major: 3,
+                                    minor: 12..=14,
+                                    ..
+                                } => frames[python_frame_index].last_was_shim,
+                                _ => true,
+                            } {
                                 break;
                             }
 
@@ -150,6 +165,7 @@ impl NativeStack {
                         module: None,
                         locals: None,
                         is_entry: true,
+                        last_was_shim: true,
                     });
                 });
 
@@ -291,6 +307,7 @@ impl NativeStack {
                     module: Some(frame.module.clone()),
                     locals: None,
                     is_entry: true,
+                    last_was_shim: true,
                 })
             }
             None => Some(Frame {
@@ -301,6 +318,7 @@ impl NativeStack {
                 short_filename: None,
                 module: Some(frame.module.clone()),
                 is_entry: true,
+                last_was_shim: true,
             }),
         }
     }

--- a/src/native_stack_trace.rs
+++ b/src/native_stack_trace.rs
@@ -97,7 +97,8 @@ impl NativeStack {
                         // merge it into the stack. (if we're out of bounds a later
                         // check will pick up - and report overall totals mismatch)
 
-                        // Merge all python frames until we hit one with `is_entry`.
+                        // Merge all python frames until we hit one with `is_entry` (py 3.11)
+                        // or `is_entry_shim` (py 3.12+)
                         while python_frame_index < frames.len() {
                             merged.push(frames[python_frame_index].clone());
 
@@ -109,9 +110,9 @@ impl NativeStack {
                                 } => frames[python_frame_index].is_entry,
                                 Version {
                                     major: 3,
-                                    minor: 12..=14,
+                                    minor: 12..,
                                     ..
-                                } => frames[python_frame_index].last_was_shim,
+                                } => frames[python_frame_index].is_shim_entry,
                                 _ => true,
                             } {
                                 break;
@@ -165,7 +166,7 @@ impl NativeStack {
                         module: None,
                         locals: None,
                         is_entry: true,
-                        last_was_shim: true,
+                        is_shim_entry: true,
                     });
                 });
 
@@ -307,7 +308,7 @@ impl NativeStack {
                     module: Some(frame.module.clone()),
                     locals: None,
                     is_entry: true,
-                    last_was_shim: true,
+                    is_shim_entry: true,
                 })
             }
             None => Some(Frame {
@@ -318,7 +319,7 @@ impl NativeStack {
                 short_filename: None,
                 module: Some(frame.module.clone()),
                 is_entry: true,
-                last_was_shim: true,
+                is_shim_entry: true,
             }),
         }
     }

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -303,7 +303,8 @@ impl PythonSpy {
                             .os_thread_id
                             .ok_or_else(|| format_err!("failed to get os threadid"))?;
                         let os_thread = remoteprocess::Thread::new(thread_id as Tid)?;
-                        trace.frames = native.merge_native_thread(&trace.frames, &os_thread)?
+                        trace.frames =
+                            native.merge_native_thread(&trace.frames, &os_thread, &self.version)?
                     }
                 }
             }

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -303,8 +303,7 @@ impl PythonSpy {
                             .os_thread_id
                             .ok_or_else(|| format_err!("failed to get os threadid"))?;
                         let os_thread = remoteprocess::Thread::new(thread_id as Tid)?;
-                        trace.frames =
-                            native.merge_native_thread(&trace.frames, &os_thread, &self.version)?
+                        trace.frames = native.merge_native_thread(&trace.frames, &os_thread)?
                     }
                 }
             }

--- a/src/speedscope.rs
+++ b/src/speedscope.rs
@@ -289,6 +289,7 @@ mod tests {
             line: 0,
             locals: None,
             is_entry: true,
+            is_shim_entry: false,
         };
 
         let trace = stack_trace::StackTrace {

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -50,7 +50,7 @@ pub struct Frame {
     /// If this is an entry frame. Each entry frame corresponds to one native frame (Python 3.11)
     pub is_entry: bool,
     /// If the last frame was a shim. This is used in Python 3.12+ to detect entry frames.
-    pub last_was_shim: bool,
+    pub is_shim_entry: bool,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Serialize)]
@@ -130,7 +130,16 @@ where
     }
 
     let mut frame_ptr = thread.frame(frame_address);
-    let mut last_was_shim = true;
+
+    // We are iterating in reverse, i.e. from last call to first call.
+    // Since Python 3.12, there are shim frames inserted before a block
+    // of Python frames. When we encounter one, update the last frame.
+    let set_last_frame_as_shim_entry = &mut |frames: &mut Vec<Frame>| {
+        if let Some(frame) = frames.last_mut() {
+            frame.is_shim_entry = true;
+        }
+    };
+
     while !frame_ptr.is_null() {
         let frame = process
             .copy_pointer(frame_ptr)
@@ -150,9 +159,10 @@ where
         // would also have to figure out what the address of PyCode_Type is (which will be
         // easier if something like https://github.com/python/cpython/issues/100987#issuecomment-1487227139
         // is merged )
+        // Unset file/function name in py3.13 means this is a shim.
         if filename.is_err() || name.is_err() {
             frame_ptr = frame.back();
-            last_was_shim = false;
+            set_last_frame_as_shim_entry(&mut frames);
             continue;
         }
         let filename = filename?;
@@ -161,7 +171,7 @@ where
         // skip <shim> entries in python 3.12+
         if filename == "<shim>" {
             frame_ptr = frame.back();
-            last_was_shim = true;
+            set_last_frame_as_shim_entry(&mut frames);
             continue;
         }
 
@@ -200,15 +210,17 @@ where
             module: None,
             locals,
             is_entry,
-            last_was_shim,
+            is_shim_entry: false,
         });
         if frames.len() > 4096 {
             return Err(format_err!("Max frame recursion depth reached"));
         }
 
         frame_ptr = frame.back();
-        last_was_shim = false;
     }
+
+    // First frame is always a shim
+    set_last_frame_as_shim_entry(&mut frames);
 
     Ok(StackTrace {
         pid: 0,
@@ -316,7 +328,7 @@ impl ProcessInfo {
             line: 0,
             locals: None,
             is_entry: true,
-            last_was_shim: true,
+            is_shim_entry: true,
         }
     }
 }


### PR DESCRIPTION
Python changed the way how entry frames are detected yet again in Python 3.12+, see https://github.com/python/cpython/issues/96421.

Now, shim frames are inserted before every block of Python frames instead of marking the first frame as `is_entry`.

Because `is_entry` is now effectively unused, merging multiple blocks of native and python frames didn't work anymore.

To resolve, we add a new field to the `Frame` struct called `is_shim_entry`, which is set when the frame was preceded by a shim frame. Because we iterate in reverse, we have to set this for the last element in the frames vector.

We could also re-use the `is_entry` field. I went with a new field because `is_entry` is still technically part of the Python frame spec and may be re-used in the future (though I think this is unlikely).