### PR TITLE
[Fix] Symbol mapping issue when we have multiple executable segment

### DIFF
--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -143,24 +143,27 @@ impl PythonProcessInfo {
 
         // likewise handle libpython for python versions compiled with --enabled-shared
         let libpython_binary = {
-            let libmap = maps.iter().find(|m| {
-                if let Some(pathname) = m.filename() {
-                    if let Some(pathname) = pathname.to_str() {
-                        #[cfg(not(windows))]
-                        {
-                            return is_python_lib(pathname) && m.is_exec();
-                        }
-                        #[cfg(windows)]
-                        {
-                            return is_python_lib(pathname);
+            let libmaps: Vec<_> = maps
+                .iter()
+                .filter(|m| {
+                    if let Some(pathname) = m.filename() {
+                        if let Some(pathname) = pathname.to_str() {
+                            #[cfg(not(windows))]
+                            {
+                                return is_python_lib(pathname) && m.is_exec();
+                            }
+                            #[cfg(windows)]
+                            {
+                                return is_python_lib(pathname);
+                            }
                         }
                     }
-                }
-                false
-            });
+                    false
+                })
+                .collect();
 
             let mut libpython_binary: Option<BinaryInfo> = None;
-            if let Some(libpython) = libmap {
+            if let Some(libpython) = libmaps.iter().min_by_key(|m| m.offset) {
                 if let Some(filename) = &libpython.filename() {
                     info!("Found libpython binary @ {}", filename.display());
 


### PR DESCRIPTION
It turns out that we can have multiple executable segment for python binaries
```
➜  py-spy git:(master) ✗ grep libpython3 /proc/3033958/maps
7b9d5718a000-7b9d5718b000 r-xp 0065e000 09:00 271849319                  /tmp/yinghai/cpython-3.12.9-linux-x86_64-gnu/lib/libpython3.12.so.1.0
7b9d580f1000-7b9d58311000 r--p 00000000 09:00 271849319                  /tmp/yinghai/cpython-3.12.9-linux-x86_64-gnu/lib/libpython3.12.so.1.0
7b9d58311000-7b9d5902e000 r-xp 00220000 09:00 271849319                  /tmp/yinghai/cpython-3.12.9-linux-x86_64-gnu/lib/libpython3.12.so.1.0
7b9d5902e000-7b9d5962a000 r--p 00f3d000 09:00 271849319                  /tmp/yinghai/cpython-3.12.9-linux-x86_64-gnu/lib/libpython3.12.so.1.0
7b9d5962a000-7b9d5974f000 r--p 01538000 09:00 271849319                  /tmp/yinghai/cpython-3.12.9-linux-x86_64-gnu/lib/libpython3.12.so.1.0
7b9d5974f000-7b9d598e6000 rw-p 0165d000 09:00 271849319                  /tmp/yinghai/cpython-3.12.9-linux-x86_64-gnu/lib/libpython3.12.so.1.0
```
Note that both segement `7b9d5718a000` and `7b9d58311000` are executable but first segment has a lower address but a higher offset than the second one. In the code to parse binary, we find the first executable with lowerest address but in symbol map resolution, we use elf in linux to find the first executable with lowest offset to get absolute address of a symbol.
https://github.com/benfred/py-spy/blob/1fa3a6ded252d7c1c0ff974a4fcd1af67a1577cf/src/binary_parser.rs#L139-L145

This inconsistency causes the symbol address to wrong. Hence py-spy will fail to find python context of the process. Typical error message is 
> Failed to find python version from target process

We have a few of such issues (https://github.com/benfred/py-spy/issues/756, https://github.com/benfred/py-spy/issues/550), which could be related although there are other reasons that can lead to this. 

The fix here is to scan all the executable segments and pick the lowest offset one to parse binary so that we are consistent. 
