### PR TITLE
make remoteprocess unwind feature optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [features]
-unwind = []
+unwind = ["remoteprocess/unwind"]
 
 [package]
 name = "py-spy"
@@ -39,7 +39,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.8"
 rand_distr = "0.4"
-remoteprocess = {version="0.5.0", features=["unwind"]}
+remoteprocess = "0.5.0"
 chrono = "0.4.26"
 
 [dev-dependencies]


### PR DESCRIPTION
i  noticed that when using `py-spy` as a dependency and _not_ using the `unwind` feature of `py-spy`, the binary still depends on `libunwind.so.8`.
with this fix, this isn't the case anymore.