### PR TITLE
Do not fail sampling completely if a single thread dies before sampling

### DIFF
--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -198,7 +198,12 @@ impl PythonSpy {
         } else {
             for thread in self.process.threads()?.iter() {
                 let threadid: Tid = thread.id()?;
-                thread_activity.insert(threadid, thread.active()?);
+                let Ok(active) = thread.active() else {
+                    // Do not fail all sampling if a single thread died between entering the loop
+                    // and reading its status.
+                    continue;
+                };
+                thread_activity.insert(threadid, active);
             }
         }
 


### PR DESCRIPTION
The flow when sampling a process starts by

1. Enumerate all threads by reading `/proc/pid/task/<tid>`.
2. For each found thread, check if it is currently active by reading its state file in `/proc/<tid>/stat`.

During this time, we *did not suspend the process yet*. Therefore, it might happen that a thread dies precisely in the milliseconds between the enumeration readdir and the stat for active checking. In those cases, py-spy bails out completely, skipping *all* threads. If a process creates a lot of threads and tears them down (e.g. through using some native dependency with a saner threading model, such as rust with polars), this case can be hit a lot.

I do not see why we would want to throw out a full sample, just because a single thread died prematurely. Therefore, I propose silently ignoring stat errors for threads. The `.threads()` method will re-enumerate and find the thread lacking, if it is called in later parts of the code.

Doing this also exposed https://github.com/benfred/remoteprocess/pull/106.

Even without this patch, sampling might fail with `EPERM`, but that is an expected quirk of ptrace: https://elixir.bootlin.com/linux/v6.15.3/source/kernel/ptrace.c#L458 if the process is currently exiting, ptrace returns `EPERM` instead of `ESRCH`.