### PR TITLE
fix stack trace fetching on 32-bit cpython 3.12 and 3.13

### DIFF
--- a/src/python_bindings/v3_12_0.rs
+++ b/src/python_bindings/v3_12_0.rs
@@ -391,9 +391,11 @@ pub struct _object {
 #[derive(Copy, Clone)]
 pub union _object__bindgen_ty_1 {
     pub ob_refcnt: Py_ssize_t,
-    #[cfg(target_pointer_width = "64")]  // line manually added, see https://github.com/benfred/py-spy/issues/753
+    // line manually added, see https://github.com/benfred/py-spy/issues/753
+    #[cfg(target_pointer_width = "64")]
     pub ob_refcnt_split: [u32; 2usize],
-    #[cfg(target_pointer_width = "64")]  // line manually added, see https://github.com/benfred/py-spy/issues/753
+    // line manually added, see https://github.com/benfred/py-spy/issues/753
+    #[cfg(target_pointer_width = "64")]
     _bindgen_union_align: u64,
 }
 impl Default for _object__bindgen_ty_1 {

--- a/src/python_bindings/v3_13_0.rs
+++ b/src/python_bindings/v3_13_0.rs
@@ -340,9 +340,11 @@ pub struct _object {
 #[derive(Copy, Clone)]
 pub union _object__bindgen_ty_1 {
     pub ob_refcnt: Py_ssize_t,
-    #[cfg(target_pointer_width = "64")]  // line manually added, see https://github.com/benfred/py-spy/issues/753
+    // line manually added, see https://github.com/benfred/py-spy/issues/753
+    #[cfg(target_pointer_width = "64")]
     pub ob_refcnt_split: [u32; 2usize],
-    #[cfg(target_pointer_width = "64")]  // line manually added, see https://github.com/benfred/py-spy/issues/753
+    // line manually added, see https://github.com/benfred/py-spy/issues/753
+    #[cfg(target_pointer_width = "64")]
     _bindgen_union_align: u64,
 }
 impl Default for _object__bindgen_ty_1 {


### PR DESCRIPTION
The stack traces fail because 32-bit and 64-bit python define struct _object differently.

See https://github.com/benfred/py-spy/issues/753#issuecomment-3006045678 for the root cause.

Fixes https://github.com/benfred/py-spy/issues/753

This is not robust against regeneration of the python bindings, but will fix things on 32-bit for now.