### PR TITLE
Test aarch64 in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,28 +215,42 @@ jobs:
             3.13.4,
             3.13.5,
           ]
-        os: [ubuntu-22.04, macos-13, windows-latest]
+        os: [ubuntu-22.04, macos-13, windows-latest, ubuntu-22.04-arm]
         # some versions of python can't be tested on GHA with osx because of SIP:
         exclude:
           - os: ubuntu-22.04
+            python-version: 3.6.7
+          - os: ubuntu-22.04-arm
             python-version: 3.6.7
           - os: windows-latest
             python-version: 3.6.15
           - os: ubuntu-22.04
             python-version: 3.6.15
+          - os: ubuntu-22.04-arm
+            python-version: 3.6.15
           - os: ubuntu-22.04
+            python-version: 3.7.1
+          - os: ubuntu-22.04-arm
             python-version: 3.7.1
           - os: windows-latest
             python-version: 3.7.17
+          - os: ubuntu-22.04-arm
+            python-version: 3.7.17
           - os: ubuntu-22.04
+            python-version: 3.8.0
+          - os: ubuntu-22.04-arm
             python-version: 3.8.0
           - os: windows-latest
             python-version: 3.8.18
           - os: ubuntu-22.04
             python-version: 3.9.0
+          - os: ubuntu-22.04-arm
+            python-version: 3.9.0
           - os: windows-latest
             python-version: 3.9.23
           - os: ubuntu-22.04
+            python-version: 3.10.0
+          - os: ubuntu-22.04-arm
             python-version: 3.10.0
           - os: windows-latest
             python-version: 3.10.18

--- a/ci/update_python_test_versions.py
+++ b/ci/update_python_test_versions.py
@@ -109,6 +109,10 @@ def update_python_test_versions():
             exclusions.append("          - os: ubuntu-22.04\n")
             exclusions.append(f"            python-version: {v}\n")
 
+        if ("linux", "arm64") not in platforms[v]:
+            exclusions.append("          - os: ubuntu-22.04-arm\n")
+            exclusions.append(f"            python-version: {v}\n")
+
     first_exclude_line = lines.index("        exclude:\n", first_line)
     last_exclude_line = lines.index("\n", first_exclude_line)
     lines = lines[: first_exclude_line + 1] + exclusions + lines[last_exclude_line:]


### PR DESCRIPTION
Github recently announced that they have github hosted aarch64 runners available for public repositories:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

We should take advantage of this to test our aarch64 wheels