### PR TITLE
RFC OTLP collector continuous export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +155,72 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -156,7 +239,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -188,6 +271,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -315,7 +404,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -353,6 +442,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -498,6 +609,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +714,25 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -596,10 +796,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -842,6 +1147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e854583a83f20cf329bb9283366335387f7db59d640d1412167e05fedb98826"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +1168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1186,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -948,6 +1276,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "git+https://github.com/korniltsev/opentelemetry-rust?rev=26cf0ac6#26cf0ac65c8dede457005384dd8ed9f0468241e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "git+https://github.com/korniltsev/opentelemetry-rust?rev=26cf0ac6#26cf0ac65c8dede457005384dd8ed9f0468241e6"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "git+https://github.com/korniltsev/opentelemetry-rust?rev=26cf0ac6#26cf0ac65c8dede457005384dd8ed9f0468241e6"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "thiserror",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1332,44 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plain"
@@ -994,7 +1399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1045,6 +1450,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "py-spy"
 version = "0.4.0"
 dependencies = [
@@ -1065,7 +1509,9 @@ dependencies = [
  "lru",
  "memmap2",
  "num-traits",
+ "opentelemetry-proto",
  "proc-maps",
+ "prost",
  "py-spy-testdata",
  "rand",
  "rand_distr",
@@ -1076,6 +1522,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "termios",
+ "tokio",
+ "tonic",
  "winapi",
 ]
 
@@ -1141,6 +1589,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1266,6 +1723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ruzstd"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,7 +1766,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1323,7 +1786,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1345,10 +1808,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1393,14 +1872,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -1453,6 +1938,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "tokio"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209a14885b74764cce87ffa777ffa1b8ce81a3f3166c6f886b83337fe7e077f"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 2.6.0",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +2120,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -1491,6 +2150,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1520,7 +2188,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -1542,7 +2210,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1759,5 +2427,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [features]
 unwind = ["remoteprocess/unwind"]
+otlp = ["opentelemetry-proto", "prost", "tonic", "tokio"]
 
 [package]
 name = "py-spy"
@@ -41,6 +42,10 @@ rand = "0.8"
 rand_distr = "0.4"
 remoteprocess = "0.5.0"
 chrono = "0.4.26"
+opentelemetry-proto = { version = "0.30.0", optional = true, features = ["tonic", "profiles", "with-serde", "gen-tonic-messages", "gen-tonic"], default-features = false }
+prost = { version = "0.13", optional = true}
+tonic = { version = "0.13", optional = true }
+tokio = { version = "1.36", features = ["rt", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]
 py-spy-testdata = "0.1.0"
@@ -50,3 +55,6 @@ termios = "0.3.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = {version = "0.3", features = ["errhandlingapi", "winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv" ]}
+
+[patch.crates-io]
+opentelemetry-proto  = { git = "https://github.com/korniltsev/opentelemetry-rust", rev = "26cf0ac6" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ mod python_interpreters;
 pub mod python_process_info;
 pub mod python_spy;
 mod python_threading;
+#[cfg(feature = "otlp")]
+mod otlp;
 pub mod sampler;
 pub mod stack_trace;
 pub mod timer;

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -1,0 +1,332 @@
+use crate::stack_trace::StackTrace;
+use anyhow::Error;
+use opentelemetry_proto::tonic::collector::profiles::v1development::profiles_service_client::ProfilesServiceClient;
+use opentelemetry_proto::tonic::collector::profiles::v1development::ExportProfilesServiceRequest;
+use opentelemetry_proto::tonic::profiles::v1development::{ProfilesDictionary, Sample};
+use opentelemetry_proto::tonic::profiles::v1development::{
+    Function, Line, Location, Mapping, Profile, ResourceProfiles, ScopeProfiles,
+};
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::ops::Drop;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::sync::Mutex;
+
+const DUMMY_MAPPING_IDX: i32 = 0;
+const DUMMY_MAPPING: Mapping = Mapping {
+    memory_start: 0,
+    memory_limit: 0,
+    file_offset: 0,
+    filename_strindex: 0,
+    attribute_indices: vec![],
+    has_functions: false,
+    has_filenames: false,
+    has_line_numbers: false,
+    has_inline_frames: false,
+};
+
+/// OTLPBuilder is responsible for building the profile data
+pub struct OTLPBuilder {
+    pd: ProfilesDictionary,
+    profile: Profile,
+    strings: HashMap<String, i32>,
+    functions: HashMap<FunctionMirror, i32>,
+    locations: HashMap<LocationMirror, i32>,
+}
+impl Default for OTLPBuilder {
+    fn default() -> Self {
+        let mut res = Self {
+            pd: ProfilesDictionary::default(),
+            profile: Profile{
+                sample_type: vec![], //todo
+                sample: vec![],
+                location_indices: vec![],
+                time_nanos: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos() as i64,
+                duration_nanos: 0, //todo
+                period_type: None,
+                period: 0,
+                comment_strindices: vec![],
+                default_sample_type_index: 0,
+                profile_id: vec![],
+                dropped_attributes_count: 0,
+                original_payload_format: "".to_string(),
+                original_payload: vec![],
+                attribute_indices: vec![],
+            },
+            strings: HashMap::default(),
+            functions: HashMap::default(),
+            locations: HashMap::default(),
+        };
+        res.str("".to_string());
+        res.pd.mapping_table.push(DUMMY_MAPPING);
+        res
+    }
+}
+impl OTLPBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record(&mut self, trace: &StackTrace) -> Result<(), Error> {
+        let mut s = Sample{
+            locations_start_index: self.profile.location_indices.len() as i32,
+            locations_length: 0,
+            value: vec![1],
+            attribute_indices: vec![],
+            link_index: None,
+            timestamps_unix_nano: vec![],
+        };
+
+        for x in &trace.frames {
+            let f = FunctionMirror {
+                name_strindex: self.str(x.name.clone()), //todo just move the whole StackTrace here and dont clone
+                filename_strindex: self.str(x.filename.clone()), //todo just move the whole StackTrace here and dont clone
+            };
+            let l = LocationMirror {
+                function_index: self.fun(f),
+                line: x.line,
+            };
+            let l = self.loc(l);
+            self.profile.location_indices.push(l);
+            s.locations_length+=1;
+        }
+
+
+        self.profile.sample.push(s);
+
+        Ok(())
+    }
+
+    pub fn take(self) -> (ProfilesDictionary, ScopeProfiles) {
+        (self.pd, ScopeProfiles{
+            scope: None,
+            profiles: vec![self.profile],
+            schema_url: "".to_string(),
+        })
+    }
+
+    fn str(&mut self, s: String) -> i32 {
+        Self::insert(&mut self.strings, &mut self.pd.string_table, s)
+    }
+
+    fn fun(&mut self, fm: FunctionMirror) -> i32 {
+        Self::insert(&mut self.functions, &mut self.pd.function_table, fm)
+    }
+
+    fn loc(&mut self, lm: LocationMirror) -> i32 {
+        Self::insert(&mut self.locations, &mut self.pd.location_table, lm)
+    }
+
+    fn insert<M, V>(hm: &mut HashMap<M, i32>, table: &mut Vec<V>, m: M) -> i32
+    where
+        M: PartialEq + Eq + Hash + Clone,
+        V: From<M>,
+    {
+        match hm.get(&m) {
+            None => {
+                let idx = table.len() as i32;
+                table.push(m.clone().into()); //todo think how this clone can be avoided for strign table
+                hm.insert(m, idx);
+                idx
+            }
+            Some(idx) => *idx,
+        }
+    }
+}
+
+/// OTLPClient is responsible for sending profile data over gRPC
+pub struct OTLPClient {
+    runtime: Runtime,
+    pub client: Arc<Mutex<ProfilesServiceClient<tonic::transport::Channel>>>,
+}
+
+impl OTLPClient {
+    pub fn new(endpoint: String) -> Result<Self, Error> {
+        let runtime = Runtime::new()
+            .map_err(|e| Error::msg(format!("Failed to create tokio runtime: {}", e)))?;
+        let c = runtime.block_on(async { ProfilesServiceClient::connect(endpoint).await })?;
+
+        Ok(Self {
+            runtime,
+            client: Arc::new(Mutex::new(c)),
+        })
+    }
+
+    pub fn export(&self, d: ProfilesDictionary, p: ScopeProfiles) {
+        let c = self.client.clone();
+        self.runtime.spawn(async move {
+            let request = ExportProfilesServiceRequest {
+                resource_profiles: vec![ResourceProfiles {
+                    resource: None,
+                    scope_profiles: vec![p],
+                    schema_url: String::new(),
+                }],
+                dictionary: Some(d),
+            };
+            let mut guard = c.lock().await;
+            match guard.export(request).await {
+                Ok(_) => {
+                    log::info!("Exported profiles to OTLP endpoint");
+                }
+                Err(e) => {
+                    log::error!("Failed to export profiles: {}", e);
+                }
+            }
+        });
+    }
+}
+
+pub struct OTLP {
+    builder: OTLPBuilder,
+    client: OTLPClient,
+}
+
+impl OTLP {
+    pub fn new(host: String) -> Result<Self, Error> {
+        Ok(Self {
+            builder: OTLPBuilder::new(),
+            client: OTLPClient::new(host)?,
+        })
+    }
+
+    pub fn record(&mut self, trace: &StackTrace) -> Result<(), Error> {
+        self.builder.record(trace)
+    }
+
+    pub fn export(&mut self) {
+        let (d, p) = std::mem::take(&mut self.builder).take();
+        self.client.export(d, p)
+    }
+}
+
+impl Drop for OTLP {
+    fn drop(&mut self) {}
+}
+
+#[derive(PartialEq, Clone, Eq, Hash)]
+struct FunctionMirror {
+    pub name_strindex: i32,
+    pub filename_strindex: i32,
+}
+
+impl From<FunctionMirror> for Function {
+    fn from(m: FunctionMirror) -> Self {
+        Self {
+            name_strindex: m.name_strindex,
+            system_name_strindex: 0,
+            filename_strindex: m.filename_strindex,
+            start_line: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Clone, Eq, Hash)]
+struct LocationMirror {
+    function_index: i32,
+    line: i32,
+}
+
+impl From<LocationMirror> for Location {
+    fn from(m: LocationMirror) -> Self {
+        Self {
+            mapping_index: Some(DUMMY_MAPPING_IDX),
+            address: 0,
+            line: vec![Line {
+                function_index: m.function_index,
+                line: m.line as i64,
+                column: 0,
+            }],
+            is_folded: false,
+            attribute_indices: vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stack_trace::{Frame, StackTrace};
+
+    fn create_mock_frame(name: &str, filename: &str, line: i32) -> Frame {
+        Frame {
+            name: name.to_string(),
+            filename: filename.to_string(),
+            module: None,
+            short_filename: Some(filename.to_string()),
+            line,
+            locals: None,
+            is_entry: false,
+            is_shim_entry: false,
+        }
+    }
+
+    fn create_mock_stack_trace(thread_id: u64, frames: Vec<Frame>) -> StackTrace {
+        StackTrace {
+            pid: 12345,
+            thread_id,
+            thread_name: Some(format!("Thread-{}", thread_id)),
+            os_thread_id: Some(thread_id + 1000),
+            active: true,
+            owns_gil: thread_id == 1,
+            frames,
+            process_info: None,
+        }
+    }
+
+    #[test]
+    fn test_otlp_export_to_localhost() {
+        // Create a couple of mock stack traces
+        let trace1 = create_mock_stack_trace(
+            1,
+            vec![
+                create_mock_frame("calculate", "math_utils.py", 42),
+                create_mock_frame("process_data", "utils.py", 25),
+                create_mock_frame("main", "main.py", 10),
+            ],
+        );
+
+        let trace2 = create_mock_stack_trace(
+            2,
+            vec![
+                create_mock_frame("parse_json", "parser.py", 67),
+                create_mock_frame("handle_request", "handler.py", 33),
+                create_mock_frame("worker_thread", "worker.py", 15),
+            ],
+        );
+
+        // Create OTLP client and record traces
+        let mut otlp = match OTLP::new("http://localhost:4040".to_string()) {
+            Ok(client) => client,
+            Err(e) => {
+                println!("[DEBUG_LOG] Failed to create OTLP client: {}. This is expected if no OTLP server is running on localhost:4040", e);
+                return; // Skip test if can't connect
+            }
+        };
+
+        // Record the stack traces
+        if let Err(e) = otlp.record(&trace1) {
+            println!("[DEBUG_LOG] Failed to record trace1: {}", e);
+        } else {
+            println!("[DEBUG_LOG] Successfully recorded trace1 with {} frames", trace1.frames.len());
+        }
+
+        if let Err(e) = otlp.record(&trace2) {
+            println!("[DEBUG_LOG] Failed to record trace2: {}", e);
+        } else {
+            println!("[DEBUG_LOG] Successfully recorded trace2 with {} frames", trace2.frames.len());
+        }
+
+        // Export the traces to localhost:4040
+        println!("[DEBUG_LOG] Exporting traces to localhost:4040");
+        otlp.export();
+
+        // Give some time for the async export to complete
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        println!("[DEBUG_LOG] OTLP test completed successfully");
+    }
+}


### PR DESCRIPTION
- Adds `--continuous` flag
- Adds otlp Recorder implementation https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto  depends on https://github.com/open-telemetry/opentelemetry-rust/pull/3077



This is very much early draft, not well tested, etc. Would like to have some early feedback if this is something could be considered merged.