### PR TITLE
fix panic with Python 3.13 shim frames

### DIFF
--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -15,6 +15,9 @@ pub fn copy_string<T: StringObject, P: ProcessMemory>(
     process: &P,
 ) -> Result<String, Error> {
     let obj = process.copy_pointer(ptr)?;
+    if obj.size() == 0 {
+        return Ok(String::new());
+    }
     if obj.size() >= 4096 {
         return Err(format_err!(
             "Refusing to copy {} chars of a string",

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -155,7 +155,6 @@ where
         // would also have to figure out what the address of PyCode_Type is (which will be
         // easier if something like https://github.com/python/cpython/issues/100987#issuecomment-1487227139
         // is merged )
-        // Unset file/function name in py3.13 means this is a shim.
         if filename.is_err() || name.is_err() {
             frame_ptr = frame.back();
             set_last_frame_as_shim_entry(&mut frames);
@@ -165,7 +164,8 @@ where
         let name = name?;
 
         // skip <shim> entries in python 3.12+
-        if filename == "<shim>" {
+        // Unset file/function name in py3.13 means this is a shim.
+        if filename.is_empty() || filename == "<shim>" {
             frame_ptr = frame.back();
             set_last_frame_as_shim_entry(&mut frames);
             continue;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -280,7 +280,7 @@ fn test_local_vars() {
     let frame = &trace.frames[0];
     let locals = frame.locals.as_ref().unwrap();
 
-    assert_eq!(locals.len(), 28);
+    assert_eq!(locals.len(), 29);
 
     let arg1 = &locals[0];
     assert_eq!(arg1.name, "arg1");
@@ -421,6 +421,11 @@ fn test_local_vars() {
     let unicode_val = local25.repr.as_ref().unwrap();
     let end = unicode_val.char_indices().map(|(i, _)| i).nth(4).unwrap();
     assert_eq!(unicode_val[0..end], *"\"测试1");
+
+    // Empty string
+    let local26 = &locals[28];
+    assert_eq!(local26.name, "local26");
+    assert_eq!(local26.repr, Some("\"\"".to_string()));
 
     // we only support dictionary lookup on python 3.6+ right now
     if runner.spy.version.major == 3 && runner.spy.version.minor >= 6 {

--- a/tests/scripts/local_vars.py
+++ b/tests/scripts/local_vars.py
@@ -42,6 +42,9 @@ def local_variable_lookup(arg1="foo", arg2=None, arg3=True):
     # https://github.com/benfred/py-spy/issues/766
     local25 = "测试1" * 500
 
+    # Empty strings should not be ignored
+    local26 = ""
+
     time.sleep(100000)
 
 


### PR DESCRIPTION
File/function names in some Py3.13 frames are empty strings.

It appears that the caller (get_stack_trace) handles this condition and expects the callee (copy_string) to return an error. The callee however panics by copying zero bytes into a vector and then calling as_ptr on it, which returns a wild pointer (0x01), which is then passed to std::slice::from_raw_parts. This is not OK even if the length passed to from_raw_parts is 0.

We could also return an empty string instead of an error (but then handling of this condition in `get_stack_trace` would have to change).

```
thread 'main' panicked at library/core/src/panicking.rs:226:5:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`

This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:117:22
   2: core::panicking::panic_nounwind_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/intrinsics/mod.rs:3196:9
   3: core::panicking::panic_nounwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:226:5
   4: core::slice::raw::from_raw_parts::precondition_check
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ub_checks.rs:68:21
   5: core::slice::raw::from_raw_parts
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ub_checks.rs:75:17
   6: py_spy::python_data_access::copy_string
             at ./src/python_data_access.rs:40:17
   7: py_spy::stack_trace::get_stack_trace
             at ./src/stack_trace.rs:148:24
   8: py_spy::stack_trace::get_stack_traces
             at ./src/stack_trace.rs:95:25
   9: py_spy::python_process_info::check_interpreter_addresses::check
             at ./src/python_process_info.rs:522:28
  10: py_spy::python_process_info::check_interpreter_addresses
             at ./src/python_process_info.rs:589:14
  11: py_spy::python_process_info::get_interpreter_address
             at ./src/python_process_info.rs:378:23
  12: py_spy::python_spy::PythonSpy::new
             at ./src/python_spy.rs:61:35
  13: py_spy::dump::print_traces
             at ./src/dump.rs:11:23
  14: py_spy::run_spy_command
             at ./src/main.rs:376:13
  15: py_spy::pyspy_main
             at ./src/main.rs:414:9
  16: py_spy::main
             at ./src/main.rs:489:23
  17: core::ops::function::FnOnce::call_once
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ops/function.rs:250:5
```