### PR TITLE
[draft] don't copy all of PyInterpreterState

### DIFF
--- a/src/coredump.rs
+++ b/src/coredump.rs
@@ -326,11 +326,18 @@ impl PythonCoreDump {
     }
 
     fn _get_stack<I: InterpreterState>(&self, config: &Config) -> Result<Vec<StackTrace>, Error> {
-        let interp: I = self.core.copy_struct(self.interpreter_address)?;
-
-        let mut traces =
-            get_stack_traces(&interp, &self.core, self.threadstate_address, Some(config))?;
-        let thread_names = thread_names_from_interpreter(&interp, &self.core, &self.version).ok();
+        let mut traces = get_stack_traces::<I, CoreDump>(
+            self.interpreter_address,
+            &self.core,
+            self.threadstate_address,
+            Some(config),
+        )?;
+        let thread_names = thread_names_from_interpreter::<I, CoreDump>(
+            self.interpreter_address,
+            &self.core,
+            &self.version,
+        )
+        .ok();
 
         for trace in &mut traces {
             if let Some(ref thread_names) = thread_names {

--- a/src/python_interpreters.rs
+++ b/src/python_interpreters.rs
@@ -24,8 +24,10 @@ pub trait InterpreterState {
     type TupleObject: TupleObject;
     const HAS_GIL_RUNTIME_STATE: bool = false;
 
-    fn head(&self) -> *mut Self::ThreadState;
-    fn modules(&self) -> *mut Self::Object;
+    /// Get a remote pointer to a pointer to PyThreadState.
+    fn threadstate_ptr_ptr(interpreter_address: usize) -> *const *const Self::ThreadState;
+    /// Get a remote pointer to a pointer to PyObject being the modules dict.
+    fn modules_ptr_ptr(interpreter_address: usize) -> *const *const Self::Object;
 }
 
 pub trait ThreadState {
@@ -115,11 +117,13 @@ macro_rules! PythonCommonImpl {
             type ListObject = $py::PyListObject;
             type TupleObject = $py::PyTupleObject;
 
-            fn head(&self) -> *mut Self::ThreadState {
-                self.tstate_head
+            fn threadstate_ptr_ptr(interpreter_address: usize) -> *const *const Self::ThreadState {
+                (interpreter_address + std::mem::offset_of!(Self, tstate_head))
+                    as *const *const Self::ThreadState
             }
-            fn modules(&self) -> *mut Self::Object {
-                self.modules
+            fn modules_ptr_ptr(interpreter_address: usize) -> *const *const Self::Object {
+                (interpreter_address + std::mem::offset_of!(Self, modules))
+                    as *const *const Self::Object
             }
         }
 
@@ -416,11 +420,13 @@ impl InterpreterState for v3_13_0::PyInterpreterState {
     type TupleObject = v3_13_0::PyTupleObject;
     const HAS_GIL_RUNTIME_STATE: bool = true;
 
-    fn head(&self) -> *mut Self::ThreadState {
-        self.threads.head
+    fn threadstate_ptr_ptr(interpreter_address: usize) -> *const *const Self::ThreadState {
+        (interpreter_address + std::mem::offset_of!(Self, threads.head))
+            as *const *const Self::ThreadState
     }
-    fn modules(&self) -> *mut Self::Object {
-        self.imports.modules
+    fn modules_ptr_ptr(interpreter_address: usize) -> *const *const Self::Object {
+        (interpreter_address + std::mem::offset_of!(Self, imports.modules))
+            as *const *const Self::Object
     }
 }
 
@@ -499,11 +505,13 @@ impl InterpreterState for v3_12_0::PyInterpreterState {
     type TupleObject = v3_12_0::PyTupleObject;
     const HAS_GIL_RUNTIME_STATE: bool = true;
 
-    fn head(&self) -> *mut Self::ThreadState {
-        self.threads.head
+    fn threadstate_ptr_ptr(interpreter_address: usize) -> *const *const Self::ThreadState {
+        (interpreter_address + std::mem::offset_of!(Self, threads.head))
+            as *const *const Self::ThreadState
     }
-    fn modules(&self) -> *mut Self::Object {
-        self.imports.modules
+    fn modules_ptr_ptr(interpreter_address: usize) -> *const *const Self::Object {
+        (interpreter_address + std::mem::offset_of!(Self, imports.modules))
+            as *const *const Self::Object
     }
 }
 
@@ -588,11 +596,12 @@ impl InterpreterState for v3_11_0::PyInterpreterState {
     type ListObject = v3_11_0::PyListObject;
     type TupleObject = v3_11_0::PyTupleObject;
 
-    fn head(&self) -> *mut Self::ThreadState {
-        self.threads.head
+    fn threadstate_ptr_ptr(interpreter_address: usize) -> *const *const Self::ThreadState {
+        (interpreter_address + std::mem::offset_of!(Self, threads.head))
+            as *const *const Self::ThreadState
     }
-    fn modules(&self) -> *mut Self::Object {
-        self.modules
+    fn modules_ptr_ptr(interpreter_address: usize) -> *const *const Self::Object {
+        (interpreter_address + std::mem::offset_of!(Self, modules)) as *const *const Self::Object
     }
 }
 

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -222,18 +222,19 @@ impl PythonSpy {
             None
         };
 
-        // Get the python interpreter, and loop over all the python threads
-        let interp: I = self
+        // Find PyThreadState, and loop over all the python threads
+        let threadstate_ptr_ptr = I::threadstate_ptr_ptr(self.interpreter_address);
+        let threads_head = self
             .process
-            .copy_struct(self.interpreter_address)
-            .context("Failed to copy PyInterpreterState from process")?;
+            .copy_pointer(threadstate_ptr_ptr)
+            .context("Failed to copy PyThreadState head pointer")?;
 
         // get the threadid of the gil if appropriate
         let gil_thread_id = get_gil_threadid::<I, Process>(self.threadstate_address, &self.process)
             .context("failed to get gil_thread_id")?;
 
         let mut traces = Vec::new();
-        let mut threads = interp.head();
+        let mut threads = threads_head;
         while !threads.is_null() {
             // Get the stack trace of the python thread
             let thread = self
@@ -262,7 +263,8 @@ impl PythonSpy {
             // for older versions of python, try using OS specific code to get the native
             // thread id (doesn't work on freebsd, or on arm/i686 processors on linux)
             if trace.os_thread_id.is_none() {
-                let mut os_thread_id = self._get_os_thread_id(python_thread_id, &interp)?;
+                let mut os_thread_id =
+                    self._get_os_thread_id::<I>(python_thread_id, threads_head)?;
 
                 // linux can see issues where pthread_ids get recycled for new OS threads,
                 // which totally breaks the caching we were doing here. Detect this and retry
@@ -271,7 +273,8 @@ impl PythonSpy {
                         info!("clearing away thread id caches, thread {} has exited", tid);
                         self.python_thread_ids.clear();
                         self.python_thread_names.clear();
-                        os_thread_id = self._get_os_thread_id(python_thread_id, &interp)?;
+                        os_thread_id =
+                            self._get_os_thread_id::<I>(python_thread_id, threads_head)?;
                     }
                 }
 
@@ -371,7 +374,7 @@ impl PythonSpy {
     fn _get_os_thread_id<I: InterpreterState>(
         &mut self,
         python_thread_id: u64,
-        _interp: &I,
+        _interp_head: *const I::ThreadState,
     ) -> Result<Option<Tid>, Error> {
         Ok(Some(python_thread_id as Tid))
     }
@@ -380,7 +383,7 @@ impl PythonSpy {
     fn _get_os_thread_id<I: InterpreterState>(
         &mut self,
         python_thread_id: u64,
-        _interp: &I,
+        _interp_head: *const I::ThreadState,
     ) -> Result<Option<Tid>, Error> {
         // If we've already know this threadid, we're good
         if let Some(thread_id) = self.python_thread_ids.get(&python_thread_id) {
@@ -404,7 +407,7 @@ impl PythonSpy {
     fn _get_os_thread_id<I: InterpreterState>(
         &mut self,
         _python_thread_id: u64,
-        _interp: &I,
+        _interp_head: *const I::ThreadState,
     ) -> Result<Option<Tid>, Error> {
         Ok(None)
     }
@@ -413,7 +416,7 @@ impl PythonSpy {
     fn _get_os_thread_id<I: InterpreterState>(
         &mut self,
         python_thread_id: u64,
-        interp: &I,
+        interp_head: *const I::ThreadState,
     ) -> Result<Option<Tid>, Error> {
         // in nonblocking mode, we can't get the threadid reliably (method here requires reading the RBX
         // register which requires a ptrace attach). fallback to heuristic thread activity here
@@ -433,7 +436,7 @@ impl PythonSpy {
 
         // Get a list of all the python thread ids
         let mut all_python_threads = HashSet::new();
-        let mut threads = interp.head();
+        let mut threads = interp_head;
         while !threads.is_null() {
             let thread = self
                 .process
@@ -522,7 +525,7 @@ impl PythonSpy {
     fn _get_os_thread_id<I: InterpreterState>(
         &mut self,
         _python_thread_id: u64,
-        _interp: &I,
+        _interp_head: *const I::ThreadState,
     ) -> Result<Option<Tid>, Error> {
         Ok(None)
     }

--- a/src/python_threading.rs
+++ b/src/python_threading.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
-use anyhow::Error;
+use anyhow::{Context, Error};
 
 use crate::python_bindings::{v3_10_0, v3_11_0, v3_12_0, v3_13_0, v3_6_6, v3_7_0, v3_8_0, v3_9_5};
 use crate::python_data_access::{copy_long, copy_string, DictIterator, PY_TPFLAGS_MANAGED_DICT};
 use crate::python_interpreters::{InterpreterState, Object, TypeObject};
 use crate::python_spy::PythonSpy;
+use remoteprocess::Process;
 
 use crate::version::Version;
 
@@ -14,12 +15,17 @@ use remoteprocess::ProcessMemory;
 /// Returns a hashmap of threadid: threadname, by inspecting the '_active' variable in the
 /// 'threading' module.
 pub fn thread_names_from_interpreter<I: InterpreterState, P: ProcessMemory>(
-    interp: &I,
+    interpreter_address: usize,
     process: &P,
     version: &Version,
 ) -> Result<HashMap<u64, String>, Error> {
+    let modules_ptr_ptr = I::modules_ptr_ptr(interpreter_address);
+    let modules: *const I::Object = process
+        .copy_pointer(modules_ptr_ptr)
+        .context("Failed to copy modules PyObject")?;
+
     let mut ret = HashMap::new();
-    for entry in DictIterator::from(process, version, interp.modules() as usize)? {
+    for entry in DictIterator::from(process, version, modules as usize)? {
         let (key, value) = entry?;
         let module_name = copy_string(key as *const I::StringObject, process)?;
         if module_name == "threading" {
@@ -78,8 +84,7 @@ pub fn thread_names_from_interpreter<I: InterpreterState, P: ProcessMemory>(
 fn _thread_name_lookup<I: InterpreterState>(
     spy: &PythonSpy,
 ) -> Result<HashMap<u64, String>, Error> {
-    let interp: I = spy.process.copy_struct(spy.interpreter_address)?;
-    thread_names_from_interpreter(&interp, &spy.process, &spy.version)
+    thread_names_from_interpreter::<I, Process>(spy.interpreter_address, &spy.process, &spy.version)
 }
 
 // try getting the threadnames, but don't sweat it if we can't. Since this relies on dictionary


### PR DESCRIPTION
This fixes [785](https://github.com/benfred/py-spy/issues/785) - stack overflow with Python 3.12 observed in debug builds.

Similarly to the reporter, I saw it locally on amd64 Linux, debug build. *It doesn't happen in release builds*.

## Analysis

It appears that the error happens when copying PyInterpreterState which is larger in 3.12 compared to the other pythons:
```
std::mem::size_of::<v3_10_0::_is>() = 113520
std::mem::size_of::<v3_11_0::_is>() = 107736
std::mem::size_of::<v3_12_0::_is>() = 383520
std::mem::size_of::<v3_13_0::_is>() = 194968
```
it's 374.53125 kiB.

Additionally, Rust is known for bloated stack usage in debug builds due to unoptimised pass-by-copy (in my understanding at least) and issues like this https://github.com/rust-lang/rust/issues/34283.

The stack sizes I observed in gdb are about 2MB. This corresponds to the default stack size in nptl (the stack overflow happens in thread 2, not the main thread).

**Stack trace with frame pointers:**
```
frame                                                                                                   stack_pointer   diff
../sysdeps/posix/raise.c:26                                                                             0x7b9d4d4ba2b0  -32
./stdlib/abort.c:73                                                                                     0x7b9d4d4ba2d0  -208
library/std/src/sys/pal/unix/mod.rs:366                                                                 0x7b9d4d4ba3a0  -16
library/std/src/rt.rs:50                                                                                0x7b9d4d4ba3b0  -208
<signal_handler_called>                                                                                 0x7b9d4d4ba480  
/home/karoline/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/remoteprocess-0.5.0/src/lib.rs:188  0x7b9d4cf08878  -348168
src/python_process_info.rs:618                                                                          0x7b9d4cf5d880  -1736096
src/python_spy.rs:65                                                                                    0x7b9d4d105620  -2784
src/python_spy.rs:107                                                                                   0x7b9d4d106100  -1584
src/sampler.rs:51                                                                                       0x7b9d4d106730  -2576
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/sys/backtrace.rs:152                    0x7b9d4d107140  -16
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/thread/mod.rs:559                       0x7b9d4d107150  -288
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panic/unwind_safe.rs:272               0x7b9d4d107270  -256
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:589                        0x7b9d4d107370  -272
__rust_try                                                                                              0x7b9d4d107480  -32
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:552                        0x7b9d4d1074a0  0
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panic.rs:359                            0x7b9d4d1074a0  0
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/thread/mod.rs:557                       0x7b9d4d1074a0  -1984
/rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ops/function.rs:250                    0x7b9d4d107c60  -32
library/alloc/src/boxed.rs:1966                                                                         0x7b9d4d107c80  0
library/alloc/src/boxed.rs:1966                                                                         0x7b9d4d107c80  0
library/std/src/sys/pal/unix/thread.rs:97                                                               0x7b9d4d107c80  -80
./nptl/pthread_create.c:448                                                                             0x7b9d4d107cd0  -176
../sysdeps/unix/sysv/linux/x86_64/clone3.S:78                                                           0x7b9d4d107d80  
```
This is 2094344B (2045.2578 kiB) in total (from the beginning to stack to the `copy_struct` function in remoteprocess which overflowed) - your numbers may differ a little because I placed 2 1024-byte long bytearrays on the stack in `pyspy_main` in order to have addresses to pass to `pthread_attr_getstacksize` in the next point.

**Double-checking thread size at runtime:**
```
(gdb) set backtrace past-main
... `up` enough times to get to nptl, then write to stack addresses reserved for this step
(gdb) p pthread_attr_getstacksize(0x7fffffffb610, 0x7fffffffb210)
$3 = 0
(gdb) p *(size_t*)0x7fffffffb210
$4 = 2048000
```


## Solution

I decided to, instead of copying `PyInterpreterState`, calculate offsets of struct of interest and copy only these structs. The error stopped manifesting after removing copying from `get_threadstate_address` and `PythonSpy::_get_stack_traces` but I removed all copying of `PyInterpreterState`.  I didn't make it very pretty by refactoring anything - `InterpreterState` now has `threadstate_ptr_ptr` and `modules_ptr_ptr` methods returning remote pointers to struct entries (which are both double pointers).

This should improve profiling performance somewhat but most likely it's the number of copies that matters, rather the size of a copy.

## Alternatives

1. Setting a higher stack size could mask this issue for some time.
2. Heap allocation would solve the issue, but require a similar number of changes.

## Questions

Is there something I may have broken that tests won't see?