### PR TITLE
Add Python 3.14 support via _Py_DebugOffsets

### DIFF
--- a/src/debug_offsets.rs
+++ b/src/debug_offsets.rs
@@ -1,0 +1,652 @@
+use anyhow::Error;
+use remoteprocess::ProcessMemory;
+
+use crate::python_bindings::v3_13_0;
+use crate::version::Version;
+
+/// Version-agnostic struct holding all debug offsets py-spy needs.
+/// Populated from `_Py_DebugOffsets` read from the target process.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct DebugOffsets {
+    pub version: u64,
+    pub free_threaded: bool,
+
+    // Runtime state
+    pub runtime_interpreters_head: u64,
+
+    // Interpreter state
+    pub interp_size: u64,
+    pub interp_threads_head: u64,
+    pub interp_imports_modules: u64,
+    pub interp_gil_runtime_state: u64,
+    pub interp_gil_runtime_state_enabled: u64,
+    pub interp_gil_runtime_state_locked: u64,
+    pub interp_gil_runtime_state_holder: u64,
+
+    // Thread state
+    pub thread_size: u64,
+    pub thread_prev: u64,
+    pub thread_next: u64,
+    pub thread_interp: u64,
+    pub thread_current_frame: u64,
+    pub thread_id: u64,
+    pub thread_native_thread_id: u64,
+
+    // Interpreter frame
+    pub frame_size: u64,
+    pub frame_previous: u64,
+    pub frame_executable: u64,
+    pub frame_instr_ptr: u64,
+    pub frame_localsplus: u64,
+    pub frame_owner: u64,
+    pub frame_tlbc_index: u64,
+
+    // Code object
+    pub code_size: u64,
+    pub code_filename: u64,
+    pub code_name: u64,
+    pub code_qualname: u64,
+    pub code_linetable: u64,
+    pub code_firstlineno: u64,
+    pub code_argcount: u64,
+    pub code_localsplusnames: u64,
+    pub code_localspluskinds: u64,
+    pub code_co_code_adaptive: u64,
+    pub code_co_tlbc: u64,
+
+    // PyObject
+    pub pyobject_size: u64,
+    pub pyobject_ob_type: u64,
+
+    // Type object
+    pub type_object_tp_name: u64,
+    pub type_object_tp_flags: u64,
+
+    // Tuple object
+    pub tuple_ob_item: u64,
+    pub tuple_ob_size: u64,
+
+    // List object
+    pub list_ob_item: u64,
+    pub list_ob_size: u64,
+
+    // Dict object
+    pub dict_ma_keys: u64,
+    pub dict_ma_values: u64,
+
+    // Float object
+    pub float_ob_fval: u64,
+
+    // Long object
+    pub long_lv_tag: u64,
+    pub long_ob_digit: u64,
+
+    // Bytes object
+    pub bytes_size: u64,
+    pub bytes_ob_size: u64,
+    pub bytes_ob_sval: u64,
+
+    // Unicode object
+    pub unicode_size: u64,
+    pub unicode_state: u64,
+    pub unicode_length: u64,
+    pub unicode_asciiobject_size: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Hand-written #[repr(C)] struct matching CPython 3.14's _Py_DebugOffsets
+// layout. All fields are u64 (matching the C definition). This struct differs
+// from 3.13 in:
+//   - interpreter_state: threads_main inserted after threads_head;
+//     code_object_generation + tlbc_generation appended.
+//   - interpreter_frame: stackpointer + tlbc_index appended.
+//   - code_object: co_tlbc appended.
+//   - set_object inserted between list_object and dict_object.
+//   - gen_object, llist_node, debugger_support appended after gc.
+// ---------------------------------------------------------------------------
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314Raw {
+    pub cookie: [u8; 8],
+    pub version: u64,
+    pub free_threaded: u64,
+
+    pub runtime_state: DebugOffsets314RuntimeState,
+    pub interpreter_state: DebugOffsets314InterpState,
+    pub thread_state: DebugOffsets314ThreadState,
+    pub interpreter_frame: DebugOffsets314Frame,
+    pub code_object: DebugOffsets314CodeObject,
+    pub pyobject: DebugOffsets314PyObject,
+    pub type_object: DebugOffsets314TypeObject,
+    pub tuple_object: DebugOffsets314TupleObject,
+    pub list_object: DebugOffsets314ListObject,
+    pub set_object: DebugOffsets314SetObject,
+    pub dict_object: DebugOffsets314DictObject,
+    pub float_object: DebugOffsets314FloatObject,
+    pub long_object: DebugOffsets314LongObject,
+    pub bytes_object: DebugOffsets314BytesObject,
+    pub unicode_object: DebugOffsets314UnicodeObject,
+    pub gc: DebugOffsets314Gc,
+    pub gen_object: DebugOffsets314GenObject,
+    pub llist_node: DebugOffsets314LlistNode,
+    pub debugger_support: DebugOffsets314DebuggerSupport,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314RuntimeState {
+    pub size: u64,
+    pub finalizing: u64,
+    pub interpreters_head: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314InterpState {
+    pub size: u64,
+    pub id: u64,
+    pub next: u64,
+    pub threads_head: u64,
+    pub threads_main: u64,
+    pub gc: u64,
+    pub imports_modules: u64,
+    pub sysdict: u64,
+    pub builtins: u64,
+    pub ceval_gil: u64,
+    pub gil_runtime_state: u64,
+    pub gil_runtime_state_enabled: u64,
+    pub gil_runtime_state_locked: u64,
+    pub gil_runtime_state_holder: u64,
+    pub code_object_generation: u64,
+    pub tlbc_generation: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314ThreadState {
+    pub size: u64,
+    pub prev: u64,
+    pub next: u64,
+    pub interp: u64,
+    pub current_frame: u64,
+    pub thread_id: u64,
+    pub native_thread_id: u64,
+    pub datastack_chunk: u64,
+    pub status: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314Frame {
+    pub size: u64,
+    pub previous: u64,
+    pub executable: u64,
+    pub instr_ptr: u64,
+    pub localsplus: u64,
+    pub owner: u64,
+    pub stackpointer: u64,
+    pub tlbc_index: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314CodeObject {
+    pub size: u64,
+    pub filename: u64,
+    pub name: u64,
+    pub qualname: u64,
+    pub linetable: u64,
+    pub firstlineno: u64,
+    pub argcount: u64,
+    pub localsplusnames: u64,
+    pub localspluskinds: u64,
+    pub co_code_adaptive: u64,
+    pub co_tlbc: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314PyObject {
+    pub size: u64,
+    pub ob_type: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314TypeObject {
+    pub size: u64,
+    pub tp_name: u64,
+    pub tp_repr: u64,
+    pub tp_flags: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314TupleObject {
+    pub size: u64,
+    pub ob_item: u64,
+    pub ob_size: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314ListObject {
+    pub size: u64,
+    pub ob_item: u64,
+    pub ob_size: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314SetObject {
+    pub size: u64,
+    pub used: u64,
+    pub table: u64,
+    pub mask: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314DictObject {
+    pub size: u64,
+    pub ma_keys: u64,
+    pub ma_values: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314FloatObject {
+    pub size: u64,
+    pub ob_fval: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314LongObject {
+    pub size: u64,
+    pub lv_tag: u64,
+    pub ob_digit: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314BytesObject {
+    pub size: u64,
+    pub ob_size: u64,
+    pub ob_sval: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314UnicodeObject {
+    pub size: u64,
+    pub state: u64,
+    pub length: u64,
+    pub asciiobject_size: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314Gc {
+    pub size: u64,
+    pub collecting: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314GenObject {
+    pub size: u64,
+    pub gi_name: u64,
+    pub gi_iframe: u64,
+    pub gi_frame_state: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314LlistNode {
+    pub next: u64,
+    pub prev: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct DebugOffsets314DebuggerSupport {
+    pub eval_breaker: u64,
+    pub remote_debugger_support: u64,
+    pub remote_debugging_enabled: u64,
+    pub debugger_pending_call: u64,
+    pub debugger_script_path: u64,
+    pub debugger_script_path_size: u64,
+}
+
+
+/// Extract shared fields from a raw debug offsets struct into DebugOffsets.
+/// The raw types (3.13 bindgen and 3.14 hand-written) have identical field names
+/// for the subset DebugOffsets uses.
+macro_rules! debug_offsets_from_raw {
+    ($raw:expr, $frame_tlbc_index:expr, $code_co_tlbc:expr) => {
+        DebugOffsets {
+            version: $raw.version,
+            free_threaded: $raw.free_threaded != 0,
+
+            runtime_interpreters_head: $raw.runtime_state.interpreters_head,
+
+            interp_size: $raw.interpreter_state.size,
+            interp_threads_head: $raw.interpreter_state.threads_head,
+            interp_imports_modules: $raw.interpreter_state.imports_modules,
+            interp_gil_runtime_state: $raw.interpreter_state.gil_runtime_state,
+            // Absolute offset from interpreter base: base of _gil + offset of enabled within it
+            interp_gil_runtime_state_enabled: $raw.interpreter_state.gil_runtime_state
+                + $raw.interpreter_state.gil_runtime_state_enabled,
+            interp_gil_runtime_state_locked: $raw.interpreter_state.gil_runtime_state_locked,
+            interp_gil_runtime_state_holder: $raw.interpreter_state.gil_runtime_state_holder,
+
+            thread_size: $raw.thread_state.size,
+            thread_prev: $raw.thread_state.prev,
+            thread_next: $raw.thread_state.next,
+            thread_interp: $raw.thread_state.interp,
+            thread_current_frame: $raw.thread_state.current_frame,
+            thread_id: $raw.thread_state.thread_id,
+            thread_native_thread_id: $raw.thread_state.native_thread_id,
+
+            frame_size: $raw.interpreter_frame.size,
+            frame_previous: $raw.interpreter_frame.previous,
+            frame_executable: $raw.interpreter_frame.executable,
+            frame_instr_ptr: $raw.interpreter_frame.instr_ptr,
+            frame_localsplus: $raw.interpreter_frame.localsplus,
+            frame_owner: $raw.interpreter_frame.owner,
+            frame_tlbc_index: $frame_tlbc_index,
+
+            code_size: $raw.code_object.size,
+            code_filename: $raw.code_object.filename,
+            code_name: $raw.code_object.name,
+            code_qualname: $raw.code_object.qualname,
+            code_linetable: $raw.code_object.linetable,
+            code_firstlineno: $raw.code_object.firstlineno,
+            code_argcount: $raw.code_object.argcount,
+            code_localsplusnames: $raw.code_object.localsplusnames,
+            code_localspluskinds: $raw.code_object.localspluskinds,
+            code_co_code_adaptive: $raw.code_object.co_code_adaptive,
+            code_co_tlbc: $code_co_tlbc,
+
+            pyobject_size: $raw.pyobject.size,
+            pyobject_ob_type: $raw.pyobject.ob_type,
+
+            type_object_tp_name: $raw.type_object.tp_name,
+            type_object_tp_flags: $raw.type_object.tp_flags,
+
+            tuple_ob_item: $raw.tuple_object.ob_item,
+            tuple_ob_size: $raw.tuple_object.ob_size,
+
+            list_ob_item: $raw.list_object.ob_item,
+            list_ob_size: $raw.list_object.ob_size,
+
+            dict_ma_keys: $raw.dict_object.ma_keys,
+            dict_ma_values: $raw.dict_object.ma_values,
+
+            float_ob_fval: $raw.float_object.ob_fval,
+
+            long_lv_tag: $raw.long_object.lv_tag,
+            long_ob_digit: $raw.long_object.ob_digit,
+
+            bytes_size: $raw.bytes_object.size,
+            bytes_ob_size: $raw.bytes_object.ob_size,
+            bytes_ob_sval: $raw.bytes_object.ob_sval,
+
+            unicode_size: $raw.unicode_object.size,
+            unicode_state: $raw.unicode_object.state,
+            unicode_length: $raw.unicode_object.length,
+            unicode_asciiobject_size: $raw.unicode_object.asciiobject_size,
+        }
+    };
+}
+
+impl DebugOffsets {
+    pub fn from_3_13(raw: &v3_13_0::_Py_DebugOffsets) -> Self {
+        debug_offsets_from_raw!(raw, 0, 0)
+    }
+
+    pub fn from_3_14(raw: &DebugOffsets314Raw) -> Self {
+        debug_offsets_from_raw!(raw, raw.interpreter_frame.tlbc_index, raw.code_object.co_tlbc)
+    }
+
+    /// Read `_Py_DebugOffsets` from a target process at the given `_PyRuntime` address.
+    pub fn read<P: ProcessMemory>(
+        process: &P,
+        runtime_addr: usize,
+        version: &Version,
+    ) -> Result<Self, Error> {
+        match version {
+            Version {
+                major: 3,
+                minor: 13,
+                ..
+            } => {
+                let raw: v3_13_0::_Py_DebugOffsets = process.copy_struct(runtime_addr)?;
+                let cookie: &[u8; 8] =
+                    unsafe { &*(&raw.cookie as *const [std::os::raw::c_char; 8] as *const [u8; 8]) };
+                validate_cookie(cookie)?;
+                Ok(Self::from_3_13(&raw))
+            }
+            Version {
+                major: 3,
+                minor: 14,
+                ..
+            } => {
+                let raw: DebugOffsets314Raw = process.copy_struct(runtime_addr)?;
+                validate_cookie(&raw.cookie)?;
+                Ok(Self::from_3_14(&raw))
+            }
+            _ => Err(format_err!(
+                "DebugOffsets not supported for Python {}.{}",
+                version.major,
+                version.minor
+            )),
+        }
+    }
+}
+
+fn validate_cookie(cookie: &[u8; 8]) -> Result<(), Error> {
+    if cookie == b"xdebugpy" {
+        Ok(())
+    } else {
+        Err(format_err!(
+            "Invalid _Py_DebugOffsets cookie: expected 'xdebugpy', got {:?}",
+            cookie
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Read primitives: extract fields from remote process memory at given offsets
+// ---------------------------------------------------------------------------
+
+/// Read a pointer-sized value from `base + offset` in the target process.
+pub fn read_ptr<P: ProcessMemory>(process: &P, base: usize, offset: u64) -> Result<usize, Error> {
+    let mut buf = [0u8; std::mem::size_of::<usize>()];
+    process.read(base + offset as usize, &mut buf)?;
+    Ok(usize::from_ne_bytes(buf))
+}
+
+/// Read a 4-byte signed integer from `base + offset`.
+pub fn read_i32<P: ProcessMemory>(process: &P, base: usize, offset: u64) -> Result<i32, Error> {
+    let mut buf = [0u8; 4];
+    process.read(base + offset as usize, &mut buf)?;
+    Ok(i32::from_ne_bytes(buf))
+}
+
+/// Read a 4-byte unsigned integer from `base + offset`.
+pub fn read_u32<P: ProcessMemory>(process: &P, base: usize, offset: u64) -> Result<u32, Error> {
+    let mut buf = [0u8; 4];
+    process.read(base + offset as usize, &mut buf)?;
+    Ok(u32::from_ne_bytes(buf))
+}
+
+/// Read an 8-byte unsigned integer from `base + offset`.
+#[allow(dead_code)]
+pub fn read_u64<P: ProcessMemory>(process: &P, base: usize, offset: u64) -> Result<u64, Error> {
+    let mut buf = [0u8; 8];
+    process.read(base + offset as usize, &mut buf)?;
+    Ok(u64::from_ne_bytes(buf))
+}
+
+/// Read a single byte (as i8) from `base + offset`.
+#[allow(dead_code)]
+pub fn read_byte<P: ProcessMemory>(process: &P, base: usize, offset: u64) -> Result<i8, Error> {
+    let mut buf = [0u8; 1];
+    process.read(base + offset as usize, &mut buf)?;
+    Ok(buf[0] as i8)
+}
+
+// ---------------------------------------------------------------------------
+// Bulk struct reading: read an entire struct in one syscall, extract fields locally
+// ---------------------------------------------------------------------------
+
+/// A buffer holding a struct's raw bytes read from a remote process.
+/// Fields are extracted locally without additional syscalls.
+pub struct StructBuf {
+    buf: Vec<u8>,
+}
+
+impl StructBuf {
+    /// Read `size` bytes from `addr` in the target process.
+    pub fn read<P: ProcessMemory>(process: &P, addr: usize, size: u64) -> Result<Self, Error> {
+        let buf = process.copy(addr, size as usize)?;
+        Ok(StructBuf { buf })
+    }
+
+    pub fn ptr_at(&self, offset: u64) -> usize {
+        let off = offset as usize;
+        let sz = std::mem::size_of::<usize>();
+        let bytes = &self.buf[off..off + sz];
+        usize::from_ne_bytes(bytes.try_into().unwrap())
+    }
+
+    pub fn i32_at(&self, offset: u64) -> i32 {
+        let off = offset as usize;
+        let bytes = &self.buf[off..off + 4];
+        i32::from_ne_bytes(bytes.try_into().unwrap())
+    }
+
+    #[allow(dead_code)]
+    pub fn u32_at(&self, offset: u64) -> u32 {
+        let off = offset as usize;
+        let bytes = &self.buf[off..off + 4];
+        u32::from_ne_bytes(bytes.try_into().unwrap())
+    }
+
+    pub fn byte_at(&self, offset: u64) -> i8 {
+        self.buf[offset as usize] as i8
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_cookie() {
+        assert!(validate_cookie(b"xdebugpy").is_ok());
+        assert!(validate_cookie(b"notvalid").is_err());
+        assert!(validate_cookie(b"\0\0\0\0\0\0\0\0").is_err());
+    }
+
+    #[test]
+    fn test_debug_offsets_314_raw_size() {
+        // Must match the CPython 3.14 _Py_DebugOffsets struct layout:
+        // cookie(8) + version(8) + free_threaded(8) + runtime_state(3*8) +
+        // interpreter_state(16*8) + thread_state(9*8) + interpreter_frame(8*8) +
+        // code_object(11*8) + pyobject(2*8) + type_object(4*8) + tuple_object(3*8) +
+        // list_object(3*8) + set_object(4*8) + dict_object(3*8) + float_object(2*8) +
+        // long_object(3*8) + bytes_object(3*8) + unicode_object(4*8) + gc(2*8) +
+        // gen_object(4*8) + llist_node(2*8) + debugger_support(6*8) = 760
+        assert_eq!(std::mem::size_of::<DebugOffsets314Raw>(), 760);
+    }
+
+    #[test]
+    fn test_debug_offsets_313_oracle() {
+        // Validate that from_3_13 produces correct values by comparing against
+        // std::mem::offset_of! on the bindgen structs.
+        use crate::python_bindings::v3_13_0::*;
+
+        let mut raw: _Py_DebugOffsets = Default::default();
+        // Populate with the same values CPython would set
+        raw.runtime_state.interpreters_head =
+            std::mem::offset_of!(pyruntimestate, interpreters.head) as u64;
+        raw.interpreter_state.threads_head =
+            std::mem::offset_of!(PyInterpreterState, threads.head) as u64;
+        raw.interpreter_state.imports_modules =
+            std::mem::offset_of!(PyInterpreterState, imports.modules) as u64;
+        raw.interpreter_frame.previous =
+            std::mem::offset_of!(_PyInterpreterFrame, previous) as u64;
+        raw.interpreter_frame.executable =
+            std::mem::offset_of!(_PyInterpreterFrame, f_executable) as u64;
+        raw.interpreter_frame.instr_ptr =
+            std::mem::offset_of!(_PyInterpreterFrame, instr_ptr) as u64;
+        raw.interpreter_frame.owner = std::mem::offset_of!(_PyInterpreterFrame, owner) as u64;
+        raw.code_object.filename = std::mem::offset_of!(PyCodeObject, co_filename) as u64;
+        raw.code_object.name = std::mem::offset_of!(PyCodeObject, co_name) as u64;
+        raw.code_object.firstlineno = std::mem::offset_of!(PyCodeObject, co_firstlineno) as u64;
+        raw.thread_state.current_frame =
+            std::mem::offset_of!(PyThreadState, current_frame) as u64;
+        raw.thread_state.thread_id = std::mem::offset_of!(PyThreadState, thread_id) as u64;
+        raw.thread_state.native_thread_id =
+            std::mem::offset_of!(PyThreadState, native_thread_id) as u64;
+        raw.thread_state.next = std::mem::offset_of!(PyThreadState, next) as u64;
+
+        let offsets = DebugOffsets::from_3_13(&raw);
+
+        assert_eq!(
+            offsets.runtime_interpreters_head,
+            std::mem::offset_of!(pyruntimestate, interpreters.head) as u64
+        );
+        assert_eq!(
+            offsets.interp_threads_head,
+            std::mem::offset_of!(PyInterpreterState, threads.head) as u64
+        );
+        assert_eq!(
+            offsets.frame_previous,
+            std::mem::offset_of!(_PyInterpreterFrame, previous) as u64
+        );
+        assert_eq!(
+            offsets.frame_executable,
+            std::mem::offset_of!(_PyInterpreterFrame, f_executable) as u64
+        );
+        assert_eq!(
+            offsets.code_filename,
+            std::mem::offset_of!(PyCodeObject, co_filename) as u64
+        );
+        assert_eq!(
+            offsets.thread_current_frame,
+            std::mem::offset_of!(PyThreadState, current_frame) as u64
+        );
+    }
+
+    #[test]
+    fn test_read_primitives_local() {
+        use remoteprocess::LocalProcess;
+
+        let local = LocalProcess;
+        let val: usize = 0xDEAD_BEEF_CAFE_BABE;
+        let addr = &val as *const usize as usize;
+
+        let result = read_ptr(&local, addr, 0).unwrap();
+        assert_eq!(result, val);
+
+        let val32: i32 = -42;
+        let addr32 = &val32 as *const i32 as usize;
+        let result32 = read_i32(&local, addr32, 0).unwrap();
+        assert_eq!(result32, -42);
+
+        let byte_val: i8 = -1;
+        let addr_byte = &byte_val as *const i8 as usize;
+        let result_byte = read_byte(&local, addr_byte, 0).unwrap();
+        assert_eq!(result_byte, -1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,11 @@ pub mod config;
 pub mod coredump;
 #[cfg(feature = "unwind")]
 mod cython;
+mod debug_offsets;
 pub mod dump;
 #[cfg(feature = "unwind")]
 mod native_stack_trace;
+mod offset_stack_trace;
 mod python_bindings;
 mod python_data_access;
 mod python_interpreters;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,12 @@ mod console_viewer;
 mod coredump;
 #[cfg(feature = "unwind")]
 mod cython;
+mod debug_offsets;
 mod dump;
 mod flamegraph;
 #[cfg(feature = "unwind")]
 mod native_stack_trace;
+mod offset_stack_trace;
 mod python_bindings;
 mod python_data_access;
 mod python_interpreters;

--- a/src/offset_stack_trace.rs
+++ b/src/offset_stack_trace.rs
@@ -1,0 +1,759 @@
+use anyhow::{Context, Error};
+use remoteprocess::ProcessMemory;
+
+use crate::config::LineNo;
+use crate::debug_offsets::{read_i32, read_ptr, read_u32, DebugOffsets, StructBuf};
+use crate::python_interpreters::get_line_number_compact;
+use crate::stack_trace::{Frame, LocalVariable, StackTrace};
+use crate::version::Version;
+
+// Flags from CPython's Include/internal/pycore_code.h
+const CO_FAST_LOCAL: u8 = 0x20;
+const CO_FAST_ARG: u8 = 0x0E; // CO_FAST_ARG_POS | CO_FAST_ARG_KW | CO_FAST_ARG_VAR
+
+/// FRAME_OWNED_BY_CSTACK changed value between 3.13 and 3.14:
+/// 3.13: FRAME_OWNED_BY_CSTACK = 3
+/// 3.14: FRAME_OWNED_BY_CSTACK = 4 (new FRAME_OWNED_BY_INTERPRETER = 3 inserted)
+fn frame_owned_by_cstack(version: &Version) -> i8 {
+    if version.minor >= 14 {
+        4
+    } else {
+        3
+    }
+}
+
+/// Extract a PyObject pointer from a _PyStackRef value (3.14+, GIL-enabled builds).
+/// In GIL-enabled builds: Py_TAG_REFCNT = 1, null = bits == 1, pointer = bits & !1.
+fn stackref_to_ptr(bits: usize) -> Option<usize> {
+    if bits == 1 {
+        return None;
+    } // PyStackRef_NULL
+    if bits & 3 == 3 {
+        return None;
+    } // tagged int
+    Some(bits & !1usize)
+}
+
+/// Read a unicode string from a PyUnicodeObject at the given address, using debug offsets.
+pub fn read_unicode_string<P: ProcessMemory>(
+    process: &P,
+    addr: usize,
+    offsets: &DebugOffsets,
+) -> Result<String, Error> {
+    if addr == 0 {
+        return Err(format_err!("null unicode object"));
+    }
+
+    // The state struct layout differs between GIL-enabled and free-threaded builds
+    // (see cpython/Include/cpython/unicodeobject.h).
+    // In GIL-enabled: interned is a 2-bit bitfield packed with the others into one u32:
+    //   interned:2 | kind:3 | compact:1 | ascii:1 | statically_allocated:1 | :24
+    // In free-threaded: interned is a full unsigned char (for atomic access), followed
+    // by the remaining bitfields in a separate unsigned int:
+    //   byte 0: interned (unsigned char)
+    //   byte 1+: kind:3 | compact:1 | ascii:1 | statically_allocated:1
+    let (kind, compact, ascii) = if offsets.free_threaded {
+        let mut buf = [0u8; 2];
+        process.read(addr + offsets.unicode_state as usize, &mut buf)?;
+        let kind_byte = buf[1];
+        let kind = (kind_byte & 7) as u32;
+        let compact = ((kind_byte >> 3) & 1) as u32;
+        let ascii = ((kind_byte >> 4) & 1) as u32;
+        (kind, compact, ascii)
+    } else {
+        let state = read_u32(process, addr, offsets.unicode_state)?;
+        let kind = (state >> 2) & 7;
+        let compact = (state >> 5) & 1;
+        let ascii = (state >> 6) & 1;
+        (kind, compact, ascii)
+    };
+
+    let length = read_ptr(process, addr, offsets.unicode_length)? as usize;
+
+    if length == 0 {
+        return Ok(String::new());
+    }
+    if length >= 4096 {
+        return Err(format_err!("Refusing to copy {} chars of a string", length));
+    }
+
+    let data_addr = if compact != 0 {
+        if ascii != 0 {
+            // Compact ASCII: data follows PyASCIIObject
+            addr + offsets.unicode_asciiobject_size as usize
+        } else {
+            // Compact non-ASCII: data follows PyCompactUnicodeObject.
+            // PyCompactUnicodeObject = PyASCIIObject + utf8_length(Py_ssize_t) + utf8(char*)
+            let compact_unicode_size =
+                offsets.unicode_asciiobject_size as usize + 2 * std::mem::size_of::<usize>();
+            addr + compact_unicode_size
+        }
+    } else {
+        // Non-compact: data pointer is stored inline. This is rare in practice.
+        // The data.any pointer lives right after the PyCompactUnicodeObject.
+        // PyCompactUnicodeObject size == offsets.unicode_size, and the data pointer
+        // is at that offset.
+        let data_ptr: usize = process.copy_struct(addr + offsets.unicode_size as usize)?;
+        data_ptr
+    };
+
+    let byte_len = length * kind as usize;
+    let bytes = process.copy(data_addr, byte_len)?;
+    crate::python_data_access::decode_unicode_bytes(kind, ascii != 0, &bytes)
+}
+
+/// Read a bytes object (e.g. co_linetable) from a PyBytesObject at the given address.
+fn read_bytes_object<P: ProcessMemory>(
+    process: &P,
+    addr: usize,
+    offsets: &DebugOffsets,
+) -> Result<Vec<u8>, Error> {
+    if addr == 0 {
+        return Err(format_err!("null bytes object"));
+    }
+
+    // ob_size is Py_ssize_t, which is pointer-sized
+    let size = read_ptr(process, addr, offsets.bytes_ob_size)? as usize;
+    if size >= 65536 {
+        return Err(format_err!("Refusing to copy {} bytes", size));
+    }
+    Ok(process.copy(addr + offsets.bytes_ob_sval as usize, size)?)
+}
+
+
+// ---------------------------------------------------------------------------
+// GIL detection
+// ---------------------------------------------------------------------------
+
+fn get_gil_thread_id<P: ProcessMemory>(
+    process: &P,
+    interpreter_address: usize,
+    offsets: &DebugOffsets,
+) -> Result<u64, Error> {
+    // In free-threaded builds, check if the GIL is enabled at all
+    if offsets.free_threaded {
+        let enabled =
+            read_i32(process, interpreter_address, offsets.interp_gil_runtime_state_enabled)?;
+        if enabled == 0 {
+            return Ok(0);
+        }
+    }
+
+    let locked = read_i32(process, interpreter_address, offsets.interp_gil_runtime_state_locked)?;
+    if locked == 0 {
+        return Ok(0);
+    }
+
+    let holder_addr = read_ptr(
+        process,
+        interpreter_address,
+        offsets.interp_gil_runtime_state_holder,
+    )?;
+    if holder_addr == 0 {
+        return Ok(0);
+    }
+
+    // Read thread_id from the holder's PyThreadState
+    let tid = read_ptr(process, holder_addr, offsets.thread_id)?;
+    Ok(tid as u64)
+}
+
+// ---------------------------------------------------------------------------
+// Stack trace collection
+// ---------------------------------------------------------------------------
+
+pub fn get_stack_traces_via_offsets<P: ProcessMemory>(
+    interpreter_address: usize,
+    process: &P,
+    offsets: &DebugOffsets,
+    version: &Version,
+    lineno: LineNo,
+    copy_locals: bool,
+) -> Result<Vec<StackTrace>, Error> {
+    let gil_thread_id = get_gil_thread_id(process, interpreter_address, offsets)?;
+
+    // Read head of thread linked list
+    let mut thread_addr: usize =
+        read_ptr(process, interpreter_address, offsets.interp_threads_head)
+            .context("Failed to read threads.head")?;
+
+    let mut ret = Vec::new();
+    let cstack_owner = frame_owned_by_cstack(version);
+
+    while thread_addr != 0 {
+        let ts = StructBuf::read(process, thread_addr, offsets.thread_size)?;
+        let thread_id = ts.ptr_at(offsets.thread_id) as u64;
+        let native_thread_id = ts.ptr_at(offsets.thread_native_thread_id);
+        let current_frame_addr = ts.ptr_at(offsets.thread_current_frame);
+
+        let frames = get_frame_stack(
+            process,
+            current_frame_addr,
+            offsets,
+            version,
+            lineno,
+            cstack_owner,
+            copy_locals,
+        )?;
+
+        let mut trace = StackTrace {
+            pid: 0,
+            thread_id,
+            thread_name: None,
+            os_thread_id: Some(native_thread_id as u64),
+            active: true,
+            owns_gil: thread_id == gil_thread_id,
+            frames,
+            process_info: None,
+        };
+
+        if let Some(last) = trace.frames.last_mut() {
+            last.is_shim_entry = true;
+        }
+
+        ret.push(trace);
+        if ret.len() > 4096 {
+            return Err(format_err!("Max thread recursion depth reached"));
+        }
+
+        thread_addr = ts.ptr_at(offsets.thread_next);
+    }
+
+    Ok(ret)
+}
+
+fn get_frame_stack<P: ProcessMemory>(
+    process: &P,
+    mut frame_addr: usize,
+    offsets: &DebugOffsets,
+    version: &Version,
+    lineno: LineNo,
+    cstack_owner: i8,
+    copy_locals: bool,
+) -> Result<Vec<Frame>, Error> {
+    let mut frames = Vec::new();
+
+    let set_last_as_shim = |frames: &mut Vec<Frame>| {
+        if let Some(f) = frames.last_mut() {
+            f.is_shim_entry = true;
+        }
+    };
+
+    while frame_addr != 0 {
+        let frame = StructBuf::read(process, frame_addr, offsets.frame_size)?;
+        let raw_executable = frame.ptr_at(offsets.frame_executable);
+        let code_addr = if version.minor >= 14 {
+            match stackref_to_ptr(raw_executable) {
+                Some(a) => a,
+                None => {
+                    frame_addr = frame.ptr_at(offsets.frame_previous);
+                    set_last_as_shim(&mut frames);
+                    continue;
+                }
+            }
+        } else if raw_executable == 0 {
+            frame_addr = frame.ptr_at(offsets.frame_previous);
+            set_last_as_shim(&mut frames);
+            continue;
+        } else {
+            raw_executable
+        };
+
+        let code = match StructBuf::read(process, code_addr, offsets.code_size) {
+            Ok(c) => c,
+            Err(_) => {
+                frame_addr = frame.ptr_at(offsets.frame_previous);
+                set_last_as_shim(&mut frames);
+                continue;
+            }
+        };
+
+        let filename_ptr = code.ptr_at(offsets.code_filename);
+        let name_ptr = code.ptr_at(offsets.code_name);
+        let filename = match read_unicode_string(process, filename_ptr, offsets) {
+            Ok(s) => s,
+            Err(_) => {
+                frame_addr = frame.ptr_at(offsets.frame_previous);
+                set_last_as_shim(&mut frames);
+                continue;
+            }
+        };
+        let name = match read_unicode_string(process, name_ptr, offsets) {
+            Ok(s) => s,
+            Err(_) => {
+                frame_addr = frame.ptr_at(offsets.frame_previous);
+                set_last_as_shim(&mut frames);
+                continue;
+            }
+        };
+
+        if filename.is_empty() || filename == "<shim>" {
+            frame_addr = frame.ptr_at(offsets.frame_previous);
+            set_last_as_shim(&mut frames);
+            continue;
+        }
+
+        let line = match lineno {
+            LineNo::NoLine => 0,
+            LineNo::First => code.i32_at(offsets.code_firstlineno),
+            LineNo::LastInstruction => {
+                let instr_ptr = frame.ptr_at(offsets.frame_instr_ptr);
+                match compute_line_number_from_bufs(
+                    process, &frame, instr_ptr, code_addr, &code, offsets,
+                ) {
+                    Ok(l) => l,
+                    Err(e) => {
+                        warn!("Failed to get line number from {}.{}: {}", filename, name, e);
+                        0
+                    }
+                }
+            }
+        };
+
+        let owner = frame.byte_at(offsets.frame_owner);
+        let is_entry = owner == cstack_owner;
+
+        let locals = if copy_locals {
+            match get_locals_via_offsets(process, frame_addr, &code, offsets, version) {
+                Ok(l) => Some(l),
+                Err(e) => {
+                    warn!("Failed to get locals for {}.{}: {}", filename, name, e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        frames.push(Frame {
+            name,
+            filename,
+            line,
+            short_filename: None,
+            module: None,
+            locals,
+            is_entry,
+            is_shim_entry: false,
+        });
+
+        if frames.len() > 4096 {
+            return Err(format_err!("Max frame recursion depth reached"));
+        }
+
+        frame_addr = frame.ptr_at(offsets.frame_previous);
+    }
+
+    Ok(frames)
+}
+
+/// Compute line number using pre-read frame instr_ptr and code StructBuf.
+/// Handles TLBC (thread-local bytecode) in free-threaded builds.
+fn compute_line_number_from_bufs<P: ProcessMemory>(
+    process: &P,
+    frame: &StructBuf,
+    instr_ptr: usize,
+    code_addr: usize,
+    code: &StructBuf,
+    offsets: &DebugOffsets,
+) -> Result<i32, Error> {
+    let default_lasti =
+        (instr_ptr as i64 - code_addr as i64 - offsets.code_co_code_adaptive as i64) as i32;
+    let lasti = if offsets.free_threaded && offsets.frame_tlbc_index != 0 {
+        let tlbc_index = frame.i32_at(offsets.frame_tlbc_index);
+        if tlbc_index > 0 && offsets.code_co_tlbc != 0 {
+            // instr_ptr is in a thread-local bytecode copy, not in co_code_adaptive.
+            let co_tlbc_ptr = code.ptr_at(offsets.code_co_tlbc);
+            if co_tlbc_ptr != 0 {
+                // _PyCodeArray: { Py_ssize_t size, int capacity, char *entries[1] }
+                let entries_offset = 16usize; // 8 + 4 + 4 padding on 64-bit
+                let ptr_size = std::mem::size_of::<usize>();
+                let entry_addr: usize = process.copy_struct(
+                    co_tlbc_ptr + entries_offset + tlbc_index as usize * ptr_size,
+                )?;
+                if entry_addr != 0 {
+                    (instr_ptr as i64 - entry_addr as i64) as i32
+                } else {
+                    default_lasti
+                }
+            } else {
+                default_lasti
+            }
+        } else {
+            default_lasti
+        }
+    } else {
+        default_lasti
+    };
+
+    let firstlineno = code.i32_at(offsets.code_firstlineno);
+
+    let linetable_ptr = code.ptr_at(offsets.code_linetable);
+    let table = read_bytes_object(process, linetable_ptr, offsets)
+        .context("Failed to copy line number table")?;
+
+    Ok(get_line_number_compact(firstlineno, lasti, &table))
+}
+
+// ---------------------------------------------------------------------------
+// Local variable reading
+// ---------------------------------------------------------------------------
+
+/// Read local variables from a frame using debug offsets.
+/// Derives nlocals from co_localspluskinds rather than reading co_nlocals
+/// (which isn't exposed in _Py_DebugOffsets).
+fn get_locals_via_offsets<P: ProcessMemory>(
+    process: &P,
+    frame_addr: usize,
+    code: &StructBuf,
+    offsets: &DebugOffsets,
+    version: &Version,
+) -> Result<Vec<LocalVariable>, Error> {
+    let argcount = code.i32_at(offsets.code_argcount) as usize;
+
+    let kinds_ptr = code.ptr_at(offsets.code_localspluskinds);
+    let kinds = read_bytes_object(process, kinds_ptr, offsets)?;
+
+    let nlocals = kinds
+        .iter()
+        .filter(|&&k| k & CO_FAST_LOCAL != 0 || k & CO_FAST_ARG != 0)
+        .count();
+
+    if nlocals == 0 {
+        return Ok(Vec::new());
+    }
+
+    let names_tuple_ptr = code.ptr_at(offsets.code_localsplusnames);
+    let names_count = read_ptr(process, names_tuple_ptr, offsets.tuple_ob_size)? as usize;
+    let names_items_addr = names_tuple_ptr + offsets.tuple_ob_item as usize;
+
+    let localsplus_addr = frame_addr + offsets.frame_localsplus as usize;
+    let ptr_size = std::mem::size_of::<usize>();
+
+    let mut ret = Vec::new();
+    for i in 0..nlocals.min(names_count) {
+        // Read the variable name from the tuple
+        let name_obj_ptr: usize = process.copy_struct(names_items_addr + i * ptr_size)?;
+        let name = match read_unicode_string(process, name_obj_ptr, offsets) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        // Read the variable's value pointer from localsplus
+        let raw_addr: usize = process.copy_struct(localsplus_addr + i * ptr_size)?;
+
+        // On 3.14+, localsplus contains _PyStackRef values that need decoding
+        let addr = if version.minor >= 14 {
+            match stackref_to_ptr(raw_addr) {
+                Some(a) => a,
+                None => continue, // null or tagged int
+            }
+        } else {
+            raw_addr
+        };
+
+        if addr == 0 {
+            continue;
+        }
+
+        ret.push(LocalVariable {
+            name,
+            addr,
+            arg: i < argcount,
+            repr: None,
+        });
+    }
+
+    Ok(ret)
+}
+
+// ---------------------------------------------------------------------------
+// Dict iteration via offsets
+// ---------------------------------------------------------------------------
+
+/// Iterate a Python dict using debug offsets for the PyDictObject fields
+/// and v3_12_0::PyDictKeysObject for the keys structure (which doesn't contain
+/// a PyObject header and is layout-stable across GIL/free-threaded builds).
+pub fn iter_dict_via_offsets<P: ProcessMemory>(
+    process: &P,
+    dict_addr: usize,
+    offsets: &DebugOffsets,
+) -> Result<Vec<(usize, usize)>, Error> {
+    let ma_keys_addr = read_ptr(process, dict_addr, offsets.dict_ma_keys)?;
+    let ma_values_addr = read_ptr(process, dict_addr, offsets.dict_ma_values)?;
+
+    let keys: crate::python_bindings::v3_12_0::PyDictKeysObject =
+        process.copy_struct(ma_keys_addr)?;
+
+    let entries_addr =
+        ma_keys_addr + (1 << keys.dk_log2_index_bytes) + std::mem::size_of_val(&keys);
+
+    // dk_kind determines the entry format:
+    //   0 = PyDictKeyEntry with hash (3 pointer-sized fields: hash, key, value)
+    //   1+ = PyDictUnicodeEntry without hash (2 pointer-sized fields: key, value)
+    let ptr_size = std::mem::size_of::<usize>();
+    let entry_has_hash = keys.dk_kind == 0;
+    let entry_size = if entry_has_hash { 3 * ptr_size } else { 2 * ptr_size };
+
+    let mut ret = Vec::new();
+    for index in 0..keys.dk_nentries as usize {
+        let addr = entries_addr + index * entry_size;
+        let (key, entry_value) = if entry_has_hash {
+            // { me_hash: Py_hash_t, me_key: *PyObject, me_value: *PyObject }
+            let me_key: usize = process.copy_struct(addr + ptr_size)?;
+            let me_value: usize = process.copy_struct(addr + 2 * ptr_size)?;
+            (me_key, me_value)
+        } else {
+            // { me_key: *PyObject, me_value: *PyObject }
+            let me_key: usize = process.copy_struct(addr)?;
+            let me_value: usize = process.copy_struct(addr + ptr_size)?;
+            (me_key, me_value)
+        };
+        if key == 0 {
+            continue;
+        }
+        let value = if ma_values_addr != 0 {
+            process.copy_struct(ma_values_addr + index * ptr_size)?
+        } else {
+            entry_value
+        };
+        ret.push((key, value));
+    }
+    Ok(ret)
+}
+
+// ---------------------------------------------------------------------------
+// Variable formatting via offsets (replaces format_variable::<I> for 3.14+)
+// ---------------------------------------------------------------------------
+
+use crate::python_data_access::{
+    PY_TPFLAGS_DICT_SUBCLASS, PY_TPFLAGS_LIST_SUBCLASS, PY_TPFLAGS_LONG_SUBCLASS,
+    PY_TPFLAGS_STRING_SUBCLASS, PY_TPFLAGS_TUPLE_SUBCLASS,
+};
+
+pub fn format_variable_via_offsets<P: ProcessMemory>(
+    process: &P,
+    offsets: &DebugOffsets,
+    addr: usize,
+    max_length: isize,
+) -> Result<String, Error> {
+    if max_length <= 5 {
+        return Ok("...".to_owned());
+    }
+
+    // Read ob_type pointer
+    let type_addr = read_ptr(process, addr, offsets.pyobject_ob_type)?;
+    if type_addr == 0 {
+        return Ok(format!("<object at 0x{addr:x}>"));
+    }
+
+    // Read tp_name (a C string pointer)
+    let tp_name_ptr = read_ptr(process, type_addr, offsets.type_object_tp_name)?;
+    let max_type_len = 128;
+    let name_bytes = process.copy(tp_name_ptr, max_type_len)?;
+    let length = name_bytes.iter().position(|&x| x == 0).unwrap_or(max_type_len);
+    let type_name = std::str::from_utf8(&name_bytes[..length])?;
+
+    // Read tp_flags
+    let flags = read_ptr(process, type_addr, offsets.type_object_tp_flags)?;
+
+    let format_int = |value: i64| {
+        if type_name == "bool" {
+            (if value > 0 { "True" } else { "False" }).to_owned()
+        } else {
+            format!("{value}")
+        }
+    };
+
+    let formatted = if flags & PY_TPFLAGS_LONG_SUBCLASS != 0 {
+        let (value, overflowed) = read_long_via_offsets(process, offsets, addr)?;
+        if overflowed {
+            if value > 0 { "+bigint".to_owned() } else { "-bigint".to_owned() }
+        } else {
+            format_int(value)
+        }
+    } else if flags & PY_TPFLAGS_STRING_SUBCLASS != 0 {
+        let value = read_unicode_string(process, addr, offsets)?
+            .replace('\'', "\\\"")
+            .replace('\n', "\\n");
+        if let Some((offset, _)) = value.char_indices().nth((max_length - 5) as usize) {
+            format!("\"{}...\"", &value[..offset])
+        } else {
+            format!("\"{value}\"")
+        }
+    } else if flags & PY_TPFLAGS_DICT_SUBCLASS != 0 {
+        let mut values = Vec::new();
+        let mut remaining = max_length - 2;
+        for (key, value) in iter_dict_via_offsets(process, addr, offsets)? {
+            let key = format_variable_via_offsets(process, offsets, key, remaining)?;
+            let value = format_variable_via_offsets(process, offsets, value, remaining)?;
+            remaining -= (key.len() + value.len()) as isize + 4;
+            if remaining <= 5 {
+                values.push("...".to_owned());
+                break;
+            }
+            values.push(format!("{key}: {value}"));
+        }
+        format!("{{{}}}", values.join(", "))
+    } else if flags & PY_TPFLAGS_LIST_SUBCLASS != 0 {
+        let ob_item = read_ptr(process, addr, offsets.list_ob_item)?;
+        let ob_size = read_ptr(process, addr, offsets.list_ob_size)? as usize;
+        let ptr_size = std::mem::size_of::<usize>();
+        let mut values = Vec::new();
+        let mut remaining = max_length - 2;
+        for i in 0..ob_size {
+            let value_ptr: usize = process.copy_struct(ob_item + i * ptr_size)?;
+            let value = format_variable_via_offsets(process, offsets, value_ptr, remaining)?;
+            remaining -= value.len() as isize + 2;
+            if remaining <= 5 { values.push("...".to_owned()); break; }
+            values.push(value);
+        }
+        format!("[{}]", values.join(", "))
+    } else if flags & PY_TPFLAGS_TUPLE_SUBCLASS != 0 {
+        let ob_size = read_ptr(process, addr, offsets.tuple_ob_size)? as usize;
+        let items_addr = addr + offsets.tuple_ob_item as usize;
+        let ptr_size = std::mem::size_of::<usize>();
+        let mut values = Vec::new();
+        let mut remaining = max_length - 2;
+        for i in 0..ob_size {
+            let value_ptr: usize = process.copy_struct(items_addr + i * ptr_size)?;
+            let value = format_variable_via_offsets(process, offsets, value_ptr, remaining)?;
+            remaining -= value.len() as isize + 2;
+            if remaining <= 5 { values.push("...".to_owned()); break; }
+            values.push(value);
+        }
+        format!("({})", values.join(", "))
+    } else if type_name == "float" {
+        let ob_fval: f64 = process.copy_struct(addr + offsets.float_ob_fval as usize)?;
+        format!("{ob_fval}")
+    } else if type_name == "NoneType" {
+        "None".to_owned()
+    } else if type_name.starts_with("numpy.") {
+        // Numpy scalars have layout: { PyObject ob_base, T obval }
+        let obval_offset = offsets.pyobject_size as usize;
+        match type_name {
+            "numpy.bool" => format_obval::<bool>(addr, obval_offset, process)?,
+            "numpy.uint8" => format_obval::<u8>(addr, obval_offset, process)?,
+            "numpy.uint16" => format_obval::<u16>(addr, obval_offset, process)?,
+            "numpy.uint32" => format_obval::<u32>(addr, obval_offset, process)?,
+            "numpy.uint64" => format_obval::<u64>(addr, obval_offset, process)?,
+            "numpy.int8" => format_obval::<i8>(addr, obval_offset, process)?,
+            "numpy.int16" => format_obval::<i16>(addr, obval_offset, process)?,
+            "numpy.int32" => format_obval::<i32>(addr, obval_offset, process)?,
+            "numpy.int64" => format_obval::<i64>(addr, obval_offset, process)?,
+            "numpy.float32" => format_obval::<f32>(addr, obval_offset, process)?,
+            "numpy.float64" => format_obval::<f64>(addr, obval_offset, process)?,
+            _ => format!("<{type_name} at 0x{addr:x}>"),
+        }
+    } else {
+        format!("<{type_name} at 0x{addr:x}>")
+    };
+
+    Ok(formatted)
+}
+
+fn format_obval<T: std::fmt::Display + Copy>(
+    addr: usize,
+    obval_offset: usize,
+    process: &impl ProcessMemory,
+) -> Result<String, Error> {
+    let result: T = process.copy_struct(addr + obval_offset)?;
+    Ok(format!("{result}"))
+}
+
+/// Read a Python int (PyLongObject) using debug offsets.
+/// Returns (value, overflowed).
+pub fn read_long_via_offsets<P: ProcessMemory>(
+    process: &P,
+    offsets: &DebugOffsets,
+    addr: usize,
+) -> Result<(i64, bool), Error> {
+    let lv_tag: usize = process.copy_struct(addr + offsets.long_lv_tag as usize)?;
+    let size = lv_tag >> 3;
+    let negative: i64 = if (lv_tag & 3) == 2 { -1 } else { 1 };
+    let digits_addr = addr + offsets.long_ob_digit as usize;
+    crate::python_data_access::decode_long(process, size, negative, digits_addr)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stackref_to_ptr() {
+        // null
+        assert_eq!(stackref_to_ptr(1), None);
+        // tagged int (both low bits set)
+        assert_eq!(stackref_to_ptr(0xFF03), None);
+        assert_eq!(stackref_to_ptr(3), None);
+        // regular pointer (tag bit 0 set = immortal)
+        assert_eq!(stackref_to_ptr(0x1000_0001), Some(0x1000_0000));
+        // regular pointer (no tag bits)
+        assert_eq!(stackref_to_ptr(0x1000_0000), Some(0x1000_0000));
+        // pointer with tag bit 0 (Py_TAG_REFCNT)
+        assert_eq!(stackref_to_ptr(0xDEAD_BEE1), Some(0xDEAD_BEE0));
+    }
+
+    #[test]
+    fn test_frame_owned_by_cstack_versions() {
+        let v313 = Version {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            release_flags: String::new(),
+            build_metadata: None,
+        };
+        let v314 = Version {
+            major: 3,
+            minor: 14,
+            patch: 0,
+            release_flags: String::new(),
+            build_metadata: None,
+        };
+        assert_eq!(frame_owned_by_cstack(&v313), 3);
+        assert_eq!(frame_owned_by_cstack(&v314), 4);
+    }
+
+    #[test]
+    fn test_get_line_number_compact_format() {
+        // Same test data as python_interpreters::tests::test_py3_11_line_numbers
+        let table = [
+            128_u8, 0, 221, 4, 8, 132, 74, 136, 118, 209, 4, 22, 212, 4, 22, 208, 4, 22, 208, 4,
+            22, 208, 4, 22,
+        ];
+        // In the trait-based code, lasti is adjusted by subtracting the offset of
+        // co_code_adaptive from the code object. For this test we pass lasti directly
+        // as if that adjustment already happened.
+        let result = get_line_number_compact(4, 214, &table);
+        assert_eq!(result, 5);
+    }
+
+    #[test]
+    fn test_read_unicode_string_local() {
+        use crate::python_data_access::tests::to_asciiobject;
+        use remoteprocess::LocalProcess;
+
+        let original = "hello_function";
+        let obj = to_asciiobject(original);
+        let addr = &obj as *const _ as usize;
+
+        // Build offsets matching the v3_7_0 (and later) PyASCIIObject layout.
+        // The state bitfield is at offset 16 (after ob_base: PyObject = 16 bytes on 64-bit).
+        // length is at offset 24 (after state u32 + padding).
+        // These values come from the actual bindgen struct layout.
+        use crate::python_bindings::v3_7_0::PyASCIIObject;
+        let offsets = DebugOffsets {
+            unicode_state: std::mem::offset_of!(PyASCIIObject, state) as u64,
+            unicode_length: std::mem::offset_of!(PyASCIIObject, length) as u64,
+            unicode_asciiobject_size: std::mem::size_of::<PyASCIIObject>() as u64,
+            unicode_size: 0, // not needed for compact+ascii
+            ..DebugOffsets::default()
+        };
+
+        let result = read_unicode_string(&LocalProcess, addr, &offsets).unwrap();
+        assert_eq!(result, original);
+    }
+}

--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -9,6 +9,29 @@ use crate::utils::offset_of;
 use crate::version::Version;
 use remoteprocess::ProcessMemory;
 
+/// Decode raw unicode bytes into a String given the kind and ascii flag.
+pub fn decode_unicode_bytes(kind: u32, ascii: bool, bytes: &[u8]) -> Result<String, Error> {
+    match (kind, ascii) {
+        (4, _) => {
+            #[allow(clippy::cast_ptr_alignment)]
+            let chars = unsafe {
+                std::slice::from_raw_parts(bytes.as_ptr() as *const char, bytes.len() / 4)
+            };
+            Ok(chars.iter().collect())
+        }
+        (2, _) => {
+            #[allow(clippy::cast_ptr_alignment)]
+            let chars = unsafe {
+                std::slice::from_raw_parts(bytes.as_ptr() as *const u16, bytes.len() / 2)
+            };
+            Ok(String::from_utf16(chars)?)
+        }
+        (1, true) => Ok(String::from_utf8(bytes.to_vec())?),
+        (1, false) => Ok(bytes.iter().map(|&b| b as char).collect()),
+        _ => Err(format_err!("Unknown string kind {}", kind)),
+    }
+}
+
 /// Copies a string from a target process. Attempts to handle unicode differences, which mostly seems to be working
 pub fn copy_string<T: StringObject, P: ProcessMemory>(
     ptr: *const T,
@@ -26,28 +49,8 @@ pub fn copy_string<T: StringObject, P: ProcessMemory>(
     }
 
     let kind = obj.kind();
-
     let bytes = process.copy(obj.address(ptr as usize), obj.size() * kind as usize)?;
-
-    match (kind, obj.ascii()) {
-        (4, _) => {
-            #[allow(clippy::cast_ptr_alignment)]
-            let chars = unsafe {
-                std::slice::from_raw_parts(bytes.as_ptr() as *const char, bytes.len() / 4)
-            };
-            Ok(chars.iter().collect())
-        }
-        (2, _) => {
-            #[allow(clippy::cast_ptr_alignment)]
-            let chars = unsafe {
-                std::slice::from_raw_parts(bytes.as_ptr() as *const u16, bytes.len() / 2)
-            };
-            Ok(String::from_utf16(chars)?)
-        }
-        (1, true) => Ok(String::from_utf8(bytes)?),
-        (1, false) => Ok(bytes.iter().map(|&b| b as char).collect()),
-        _ => Err(format_err!("Unknown string kind {}", kind)),
-    }
+    decode_unicode_bytes(kind, obj.ascii(), &bytes)
 }
 
 /// Copies data from a PyBytesObject (currently only lnotab object)
@@ -63,19 +66,54 @@ pub fn copy_bytes<T: BytesObject, P: ProcessMemory>(
     Ok(process.copy(obj.address(ptr as usize), size as usize)?)
 }
 
+/// Decode a Python int from pre-extracted size, sign, and digit address.
+/// Returns (value, overflowed).
+pub fn decode_long<P: ProcessMemory>(
+    process: &P,
+    size: usize,
+    negative: i64,
+    digits_addr: usize,
+) -> Result<(i64, bool), Error> {
+    match size {
+        0 => Ok((0, false)),
+        1 => {
+            let digit: u32 = process.copy_struct(digits_addr)?;
+            Ok((negative * digit as i64, false))
+        }
+        #[cfg(target_pointer_width = "64")]
+        2 => {
+            let digits: [u32; 2] = process.copy_struct(digits_addr)?;
+            let mut ret: i64 = 0;
+            for (i, &digit) in digits[..size].iter().enumerate() {
+                ret += (digit as i64) << (30 * i);
+            }
+            Ok((negative * ret, false))
+        }
+        #[cfg(target_pointer_width = "32")]
+        2..=4 => {
+            let digits: [u16; 4] = process.copy_struct(digits_addr)?;
+            let mut ret: i64 = 0;
+            for (i, &digit) in digits[..size].iter().enumerate() {
+                ret += (digit as i64) << (15 * i);
+            }
+            Ok((negative * ret, false))
+        }
+        _ => Ok((size as i64, true)),
+    }
+}
+
 /// Copies a i64 from a PyLongObject. Returns the value + if it overflowed
 pub fn copy_long<P: ProcessMemory>(
     process: &P,
     version: &Version,
     addr: usize,
 ) -> Result<(i64, bool), Error> {
-    let (size, negative, digit, value_size) = match version {
+    let (size, negative, digits_addr) = match version {
         Version {
             major: 3,
-            minor: 12..=13,
+            minor: 12..=14,
             ..
         } => {
-            // PyLongObject format changed in python 3.12
             let value = process
                 .copy_pointer(addr as *const crate::python_bindings::v3_12_0::PyLongObject)?;
             let size = value.long_value.lv_tag >> 3;
@@ -84,54 +122,25 @@ pub fn copy_long<P: ProcessMemory>(
             } else {
                 1
             };
-            (
-                size,
-                negative,
-                value.long_value.ob_digit[0] as u32,
-                std::mem::size_of_val(&value),
-            )
+            let digits_addr = addr
+                + std::mem::offset_of!(
+                    crate::python_bindings::v3_12_0::PyLongObject,
+                    long_value.ob_digit
+                );
+            (size, negative, digits_addr)
         }
         _ => {
-            // this is PyLongObject for a specific version of python, but this works since it's binary compatible
-            // layout across versions we're targeting
             let value = process
                 .copy_pointer(addr as *const crate::python_bindings::v3_7_0::PyLongObject)?;
             let negative: i64 = if value.ob_base.ob_size < 0 { -1 } else { 1 };
             let size = (value.ob_base.ob_size * (negative as isize)) as usize;
-            (
-                size,
-                negative,
-                value.ob_digit[0] as u32,
-                std::mem::size_of_val(&value),
-            )
+            let digits_addr =
+                addr + std::mem::offset_of!(crate::python_bindings::v3_7_0::PyLongObject, ob_digit);
+            (size, negative, digits_addr)
         }
     };
 
-    match size {
-        0 => Ok((0, false)),
-        1 => Ok((negative * (digit as i64), false)),
-
-        #[cfg(target_pointer_width = "64")]
-        2 => {
-            let digits: [u32; 2] = process.copy_struct(addr + value_size - 8)?;
-            let mut ret: i64 = 0;
-            for i in 0..size {
-                ret += (digits[i as usize] as i64) << (30 * i);
-            }
-            Ok((negative * ret, false))
-        }
-        #[cfg(target_pointer_width = "32")]
-        2..=4 => {
-            let digits: [u16; 4] = process.copy_struct(addr + value_size - 4)?;
-            let mut ret: i64 = 0;
-            for i in 0..size {
-                ret += (digits[i as usize] as i64) << (15 * i);
-            }
-            Ok((negative * ret, false))
-        }
-        // we don't support arbitrary sized integers yet, signal this by returning that we've overflowed
-        _ => Ok((size as i64, true)),
-    }
+    decode_long(process, size, negative, digits_addr)
 }
 
 /// Copies a i64 from a python 2.7 PyIntObject
@@ -227,7 +236,7 @@ impl<'a, P: ProcessMemory> DictIterator<'a, P> {
         match version {
             Version {
                 major: 3,
-                minor: 11..=13,
+                minor: 11..=14,
                 ..
             } => {
                 let dict: crate::python_bindings::v3_11_0::PyDictObject =
@@ -344,13 +353,13 @@ impl<'a, P: ProcessMemory> Iterator for DictIterator<'a, P> {
 
 pub const PY_TPFLAGS_INLINE_VALUES: usize = 1 << 2;
 pub const PY_TPFLAGS_MANAGED_DICT: usize = 1 << 4;
-const PY_TPFLAGS_INT_SUBCLASS: usize = 1 << 23;
-const PY_TPFLAGS_LONG_SUBCLASS: usize = 1 << 24;
-const PY_TPFLAGS_LIST_SUBCLASS: usize = 1 << 25;
-const PY_TPFLAGS_TUPLE_SUBCLASS: usize = 1 << 26;
-const PY_TPFLAGS_BYTES_SUBCLASS: usize = 1 << 27;
-const PY_TPFLAGS_STRING_SUBCLASS: usize = 1 << 28;
-const PY_TPFLAGS_DICT_SUBCLASS: usize = 1 << 29;
+pub const PY_TPFLAGS_INT_SUBCLASS: usize = 1 << 23;
+pub const PY_TPFLAGS_LONG_SUBCLASS: usize = 1 << 24;
+pub const PY_TPFLAGS_LIST_SUBCLASS: usize = 1 << 25;
+pub const PY_TPFLAGS_TUPLE_SUBCLASS: usize = 1 << 26;
+pub const PY_TPFLAGS_BYTES_SUBCLASS: usize = 1 << 27;
+pub const PY_TPFLAGS_STRING_SUBCLASS: usize = 1 << 28;
+pub const PY_TPFLAGS_DICT_SUBCLASS: usize = 1 << 29;
 
 /// Converts a python variable in the other process to a human readable string
 pub fn format_variable<I, P>(

--- a/src/python_interpreters.rs
+++ b/src/python_interpreters.rs
@@ -248,7 +248,7 @@ macro_rules! PythonCodeObjectImpl {
     };
 }
 
-fn read_varint(index: &mut usize, table: &[u8]) -> Option<usize> {
+pub fn read_varint(index: &mut usize, table: &[u8]) -> Option<usize> {
     if *index >= table.len() {
         return None;
     }
@@ -270,13 +270,57 @@ fn read_varint(index: &mut usize, table: &[u8]) -> Option<usize> {
     Some(ret)
 }
 
-fn read_signed_varint(index: &mut usize, table: &[u8]) -> Option<isize> {
+pub fn read_signed_varint(index: &mut usize, table: &[u8]) -> Option<isize> {
     let unsigned_val = read_varint(index, table)?;
     if unsigned_val & 1 != 0 {
         Some(-((unsigned_val >> 1) as isize))
     } else {
         Some((unsigned_val >> 1) as isize)
     }
+}
+
+/// Decode line number from the compact line table format used in Python 3.11+.
+/// `lasti` should already be adjusted for `co_code_adaptive` offset.
+pub fn get_line_number_compact(first_lineno: i32, lasti: i32, table: &[u8]) -> i32 {
+    let mut line_number: i32 = first_lineno;
+    let mut bytecode_address: i32 = 0;
+    let mut index: usize = 0;
+
+    loop {
+        if index >= table.len() {
+            break;
+        }
+        let byte = table[index];
+        index += 1;
+
+        let delta = ((byte & 7) as i32) + 1;
+        bytecode_address += delta * 2;
+        let code = (byte >> 3) & 15;
+        let line_delta = match code {
+            15 => 0,
+            14 => {
+                let delta = read_signed_varint(&mut index, table).unwrap_or(0);
+                read_varint(&mut index, table); // end line
+                read_varint(&mut index, table); // start column
+                read_varint(&mut index, table); // end column
+                delta
+            }
+            13 => read_signed_varint(&mut index, table).unwrap_or(0),
+            10..=12 => {
+                index += 2; // start column / end column
+                (code - 10).into()
+            }
+            _ => {
+                index += 1; // column
+                0
+            }
+        };
+        line_number += line_delta as i32;
+        if bytecode_address >= lasti {
+            break;
+        }
+    }
+    line_number
 }
 
 // Use for 3.11 and 3.12
@@ -310,48 +354,8 @@ macro_rules! CompactCodeObjectImpl {
             }
 
             fn get_line_number(&self, lasti: i32, table: &[u8]) -> i32 {
-                // unpack compressed table format from python 3.11
-                // https://github.com/python/cpython/pull/91666/files
                 let lasti = lasti - offset_of(self, &self.co_code_adaptive) as i32;
-                let mut line_number: i32 = self.first_lineno();
-                let mut bytecode_address: i32 = 0;
-
-                let mut index: usize = 0;
-                loop {
-                    if index >= table.len() {
-                        break;
-                    }
-                    let byte = table[index];
-                    index += 1;
-
-                    let delta = ((byte & 7) as i32) + 1;
-                    bytecode_address += delta * 2;
-                    let code = (byte >> 3) & 15;
-                    let line_delta = match code {
-                        15 => 0,
-                        14 => {
-                            let delta = read_signed_varint(&mut index, table).unwrap_or(0);
-                            read_varint(&mut index, table); // end line
-                            read_varint(&mut index, table); // start column
-                            read_varint(&mut index, table); // end column
-                            delta
-                        }
-                        13 => read_signed_varint(&mut index, table).unwrap_or(0),
-                        10..=12 => {
-                            index += 2; // start column / end column
-                            (code - 10).into()
-                        }
-                        _ => {
-                            index += 1; // column
-                            0
-                        }
-                    };
-                    line_number += line_delta as i32;
-                    if bytecode_address >= lasti {
-                        break;
-                    }
-                }
-                line_number
+                get_line_number_compact(self.first_lineno(), lasti, table)
             }
         }
     };

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -16,6 +16,7 @@ use remoteprocess::ProcessMemory;
 
 use crate::binary_parser::{parse_binary, BinaryInfo};
 use crate::config::Config;
+use crate::debug_offsets::{read_ptr, DebugOffsets};
 use crate::python_bindings::{
     pyruntime, v2_7_15, v3_10_0, v3_11_0, v3_12_0, v3_13_0, v3_3_7, v3_5_5, v3_6_6, v3_7_0, v3_8_0,
     v3_9_5,
@@ -376,6 +377,35 @@ where
     match version {
         Version {
             major: 3,
+            minor: 14,
+            ..
+        } => {
+            if let Some(&runtime_addr) = python_info.get_symbol("_PyRuntime") {
+                let offsets = DebugOffsets::read(process, runtime_addr as usize, version)?;
+                let interp_addr: usize = process.copy_struct(
+                    runtime_addr as usize + offsets.runtime_interpreters_head as usize,
+                )?;
+
+                match check_interpreter_via_offsets(
+                    interp_addr,
+                    &*python_info.maps,
+                    process,
+                    &offsets,
+                ) {
+                    Ok(addr) => return Ok(addr),
+                    Err(e) => {
+                        warn!(
+                            "Interpreter address from _PyRuntime symbol is invalid {:016x}: {}",
+                            interp_addr, e
+                        );
+                    }
+                };
+            } else {
+                warn!("_PyRuntime symbol not found for Python 3.14");
+            }
+        }
+        Version {
+            major: 3,
             minor: 13,
             ..
         } => {
@@ -484,6 +514,9 @@ where
 
     // We're going to scan the BSS/data section for things, and try to narrowly scan things that
     // look like pointers to PyinterpreterState
+    if binary.bss_size == 0 {
+        return Err(format_err!("BSS section is empty"));
+    }
     let bss = process.copy(binary.bss_addr as usize, binary.bss_size as usize)?;
 
     #[allow(clippy::cast_ptr_alignment)]
@@ -602,8 +635,68 @@ where
             minor: 13,
             ..
         } => check::<v3_13_0::_is, P>(addrs, maps, process),
+        Version {
+            major: 3,
+            minor: 14,
+            ..
+        } => {
+            // For 3.14 we don't have bindgen structs — validate using debug offsets.
+            // This BSS-scan fallback should never be reached in practice: 3.14
+            // always has _PyRuntime, so the symbol-based path above handles it.
+            // We use 3.13 offsets as a best-effort approximation; if a future
+            // version moves threads.head or thread.interp, the proper fix is to
+            // read debug offsets (which requires _PyRuntime, making this moot).
+            let offsets = DebugOffsets {
+                interp_threads_head: std::mem::offset_of!(v3_13_0::PyInterpreterState, threads.head) as u64,
+                thread_interp: std::mem::offset_of!(v3_13_0::PyThreadState, interp) as u64,
+                ..DebugOffsets::default()
+            };
+            check_via_offsets(addrs, maps, process, &offsets)
+        }
         _ => Err(format_err!("Unsupported version of Python: {}", version)),
     }
+}
+
+/// Offset-based interpreter address validation — equivalent to `check::<I>` but
+/// uses runtime offsets instead of compile-time struct layouts.
+fn check_interpreter_via_offsets<P: ProcessMemory>(
+    addr: usize,
+    maps: &dyn ContainsAddr,
+    process: &P,
+    offsets: &DebugOffsets,
+) -> Result<usize, Error> {
+    check_via_offsets(&[addr], maps, process, offsets)
+}
+
+fn check_via_offsets<P: ProcessMemory>(
+    addrs: &[usize],
+    maps: &dyn ContainsAddr,
+    process: &P,
+    offsets: &DebugOffsets,
+) -> Result<usize, Error> {
+    for &addr in addrs {
+        if !maps.contains_addr(addr) {
+            continue;
+        }
+        let threads_head = match read_ptr(process, addr, offsets.interp_threads_head) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if threads_head == 0 || !maps.contains_addr(threads_head) {
+            continue;
+        }
+        // Verify the thread points back to this interpreter
+        let interp_back = match read_ptr(process, threads_head, offsets.thread_interp) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        if interp_back == addr {
+            return Ok(addr);
+        }
+    }
+    Err(format_err!(
+        "Failed to find a python interpreter via offset-based validation"
+    ))
 }
 
 pub fn get_threadstate_address<P>(
@@ -617,6 +710,21 @@ where
     P: ProcessMemory,
 {
     let threadstate_address = match version {
+        Version {
+            major: 3,
+            minor: 14,
+            ..
+        } => {
+            // The offset-based stack trace path handles GIL detection internally,
+            // so we just need the inline _gil struct address for initialization.
+            if let Some(&runtime_addr) = python_info.get_symbol("_PyRuntime") {
+                let offsets = DebugOffsets::read(process, runtime_addr as usize, version)?;
+                interpreter_address + offsets.interp_gil_runtime_state as usize
+            } else {
+                error_if_gil(config, version, "failed to find _PyRuntime symbol for 3.14")?;
+                0
+            }
+        }
         Version {
             major: 3,
             minor: 13,
@@ -767,7 +875,7 @@ pub fn get_windows_python_symbols(
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub fn is_python_lib(pathname: &str) -> bool {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"/libpython\d.\d\d?(m|d|u)?.so").unwrap();
+        static ref RE: Regex = Regex::new(r"/libpython\d[.]\d\d?[mdut]?[.]so").unwrap();
     }
     RE.is_match(pathname)
 }
@@ -775,7 +883,7 @@ pub fn is_python_lib(pathname: &str) -> bool {
 #[cfg(target_os = "macos")]
 pub fn is_python_lib(pathname: &str) -> bool {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"/libpython\d.\d\d?(m|d|u)?.(dylib|so)$").unwrap();
+        static ref RE: Regex = Regex::new(r"/libpython\d[.]\d\d?[mdut]?[.](dylib|so)$").unwrap();
     }
     RE.is_match(pathname) || is_python_framework(pathname)
 }
@@ -783,7 +891,7 @@ pub fn is_python_lib(pathname: &str) -> bool {
 #[cfg(windows)]
 pub fn is_python_lib(pathname: &str) -> bool {
     lazy_static! {
-        static ref RE: Regex = RegexBuilder::new(r"\\python\d\d\d?(m|d|u)?.dll$")
+        static ref RE: Regex = RegexBuilder::new(r"\\python\d\d\d?[mdut]?[.]dll$")
             .case_insensitive(true)
             .build()
             .unwrap();

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -9,10 +9,11 @@ use anyhow::{Context, Error, Result};
 use remoteprocess::{Pid, Process, ProcessMemory, Tid};
 
 use crate::config::{Config, LockingStrategy};
+use crate::debug_offsets::DebugOffsets;
 #[cfg(feature = "unwind")]
 use crate::native_stack_trace::NativeStack;
 use crate::python_bindings::{
-    v2_7_15, v3_10_0, v3_11_0, v3_12_0, v3_13_0, v3_3_7, v3_5_5, v3_6_6, v3_7_0, v3_8_0, v3_9_5,
+    v2_7_15, v3_10_0, v3_11_0, v3_12_0, v3_3_7, v3_5_5, v3_6_6, v3_7_0, v3_8_0, v3_9_5,
 };
 use crate::python_data_access::format_variable;
 use crate::python_interpreters::{InterpreterState, ThreadState};
@@ -36,6 +37,7 @@ pub struct PythonSpy {
     pub short_filenames: HashMap<String, Option<String>>,
     pub python_thread_ids: HashMap<u64, Tid>,
     pub python_thread_names: HashMap<u64, String>,
+    pub debug_offsets: Option<DebugOffsets>,
     #[cfg(target_os = "linux")]
     pub dockerized: bool,
 }
@@ -70,6 +72,22 @@ impl PythonSpy {
             config,
         )?;
 
+        let debug_offsets = if version.minor >= 13 {
+            if let Some(&runtime_addr) = python_info.get_symbol("_PyRuntime") {
+                match DebugOffsets::read(&process, runtime_addr as usize, &version) {
+                    Ok(offsets) => Some(offsets),
+                    Err(e) => {
+                        warn!("Failed to read _Py_DebugOffsets: {}", e);
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         #[cfg(feature = "unwind")]
         let native = if config.native {
             Some(NativeStack::new(
@@ -95,6 +113,7 @@ impl PythonSpy {
             short_filenames: HashMap::new(),
             python_thread_ids: HashMap::new(),
             python_thread_names: HashMap::new(),
+            debug_offsets,
         })
     }
 
@@ -185,7 +204,12 @@ impl PythonSpy {
                 major: 3,
                 minor: 13,
                 ..
-            } => self._get_stack_traces::<v3_13_0::_is>(),
+            } => self.get_stack_traces_via_offsets(),
+            Version {
+                major: 3,
+                minor: 14,
+                ..
+            } => self.get_stack_traces_via_offsets(),
             _ => Err(format_err!(
                 "Unsupported version of Python: {}",
                 self.version
@@ -193,29 +217,10 @@ impl PythonSpy {
         }
     }
 
-    // implementation of get_stack_traces, where we have a type for the InterpreterState
     fn _get_stack_traces<I: InterpreterState>(&mut self) -> Result<Vec<StackTrace>, Error> {
-        // Query the OS to get if each thread in the process is running or not
-        let mut thread_activity = HashMap::new();
-        if self.config.gil_only {
-            // Don't need to collect thread activity if we're only getting the
-            // GIL thread: If we're holding the GIL we're by definition active.
-        } else {
-            for thread in self.process.threads()?.iter() {
-                let threadid: Tid = thread.id()?;
-                let Ok(active) = thread.active() else {
-                    // Do not fail all sampling if a single thread died between entering the loop
-                    // and reading its status.
-                    continue;
-                };
-                thread_activity.insert(threadid, active);
-            }
-        }
+        let thread_activity = self._collect_thread_activity()?;
 
-        // Lock the process if appropriate. Note we have to lock AFTER getting the thread
-        // activity status from the OS (otherwise each thread would report being inactive always).
-        // This has the potential for race conditions (in that the thread activity could change
-        // between getting the status and locking the thread, but seems unavoidable right now
+        // Lock after getting thread activity (otherwise all threads report inactive)
         let _lock = if self.config.blocking == LockingStrategy::Lock {
             Some(self.process.lock().context("Failed to suspend process")?)
         } else {
@@ -262,12 +267,11 @@ impl PythonSpy {
             // python 3.11+ has the native thread id directly on the PyThreadState object,
             // for older versions of python, try using OS specific code to get the native
             // thread id (doesn't work on freebsd, or on arm/i686 processors on linux)
+            // For older Python (<3.11), native thread id isn't on the thread state
             if trace.os_thread_id.is_none() {
                 let mut os_thread_id =
                     self._get_os_thread_id::<I>(python_thread_id, threads_head)?;
 
-                // linux can see issues where pthread_ids get recycled for new OS threads,
-                // which totally breaks the caching we were doing here. Detect this and retry
                 if let Some(tid) = os_thread_id {
                     if !thread_activity.is_empty() && !thread_activity.contains_key(&tid) {
                         info!("clearing away thread id caches, thread {} has exited", tid);
@@ -281,72 +285,22 @@ impl PythonSpy {
                 trace.os_thread_id = os_thread_id.map(|id| id as u64);
             }
 
-            trace.thread_name = self._get_python_thread_name(python_thread_id);
             trace.owns_gil = owns_gil;
-            trace.pid = self.process.pid;
-
-            // Figure out if the thread is sleeping from the OS if possible
-            trace.active = true;
-            if let Some(id) = trace.os_thread_id {
-                let id = id as Tid;
-                if let Some(active) = thread_activity.get(&id as _) {
-                    trace.active = *active;
-                }
-            }
-
-            // fallback to using a heuristic if we think the thread is still active
-            // Note that on linux the OS thread activity can only be gotten on x86_64
-            // processors and even then seems to be wrong occasionally in thinking 'select'
-            // calls are active (which seems related to the thread locking code,
-            // this problem doesn't seem to happen with the --nonblocking option)
-            // Note: this should be done before the native merging for correct results
-            if trace.active {
-                trace.active = !self._heuristic_is_thread_idle(&trace);
-            }
-
-            // Merge in the native stack frames if necessary
-            #[cfg(feature = "unwind")]
-            {
-                if self.config.native {
-                    if let Some(native) = self.native.as_mut() {
-                        let thread_id = trace
-                            .os_thread_id
-                            .ok_or_else(|| format_err!("failed to get os threadid"))?;
-                        let os_thread = remoteprocess::Thread::new(thread_id as Tid)?;
-                        trace.frames = native.merge_native_thread(&trace.frames, &os_thread)?
-                    }
-                }
-            }
-
-            for frame in &mut trace.frames {
-                frame.short_filename = self.shorten_filename(&frame.filename);
-                if let Some(locals) = frame.locals.as_mut() {
-                    let max_length = (128 * self.config.dump_locals) as isize;
-                    for local in locals {
-                        let repr = format_variable::<I, Process>(
-                            &self.process,
-                            &self.version,
-                            local.addr,
-                            max_length,
-                        );
-                        local.repr = Some(repr.unwrap_or_else(|_| "?".to_owned()));
-                    }
-                }
-            }
-
             traces.push(trace);
 
-            // This seems to happen occasionally when scanning BSS addresses for valid interpreters
             if traces.len() > 4096 {
                 return Err(format_err!("Max thread recursion depth reached"));
             }
 
             if self.config.gil_only {
-                // There's only one GIL thread and we've captured it, so we can
-                // stop now
                 break;
             }
         }
+
+        self._enrich_traces(&mut traces, &thread_activity, |process, version, addr, max_len| {
+            format_variable::<I, Process>(process, version, addr, max_len)
+        })?;
+
         Ok(traces)
     }
 
@@ -592,5 +546,106 @@ impl PythonSpy {
         self.short_filenames
             .insert(filename.to_owned(), shortened.clone());
         shortened
+    }
+
+    /// Get stack traces using the offset-based path.
+    pub fn get_stack_traces_via_offsets(&mut self) -> Result<Vec<StackTrace>, Error> {
+        let offsets = self.debug_offsets.clone().ok_or_else(|| {
+            format_err!(
+                "Offset-based reading not available for Python {}",
+                self.version
+            )
+        })?;
+
+        let thread_activity = self._collect_thread_activity()?;
+
+        let _lock = if self.config.blocking == LockingStrategy::Lock {
+            Some(self.process.lock().context("Failed to suspend process")?)
+        } else {
+            None
+        };
+
+        let mut traces = crate::offset_stack_trace::get_stack_traces_via_offsets(
+            self.interpreter_address,
+            &self.process,
+            &offsets,
+            &self.version,
+            self.config.lineno,
+            self.config.dump_locals > 0,
+        )?;
+
+        if self.config.gil_only {
+            traces.retain(|t| t.owns_gil);
+        }
+
+        self._enrich_traces(&mut traces, &thread_activity, |process, _version, addr, max_len| {
+            crate::offset_stack_trace::format_variable_via_offsets(process, &offsets, addr, max_len)
+        })?;
+
+        Ok(traces)
+    }
+
+    fn _collect_thread_activity(&self) -> Result<HashMap<Tid, bool>, Error> {
+        let mut thread_activity = HashMap::new();
+        if !self.config.gil_only {
+            for thread in self.process.threads()?.iter() {
+                let threadid: Tid = thread.id()?;
+                let Ok(active) = thread.active() else {
+                    continue;
+                };
+                thread_activity.insert(threadid, active);
+            }
+        }
+        Ok(thread_activity)
+    }
+
+    fn _enrich_traces(
+        &mut self,
+        traces: &mut [StackTrace],
+        thread_activity: &HashMap<Tid, bool>,
+        format_var: impl Fn(&Process, &Version, usize, isize) -> Result<String, Error>,
+    ) -> Result<(), Error> {
+        for trace in traces.iter_mut() {
+            trace.pid = self.process.pid;
+            trace.thread_name = self._get_python_thread_name(trace.thread_id);
+
+            if let Some(id) = trace.os_thread_id {
+                let id = id as Tid;
+                if let Some(active) = thread_activity.get(&id) {
+                    trace.active = *active;
+                }
+            }
+
+            if trace.active {
+                trace.active = !self._heuristic_is_thread_idle(trace);
+            }
+
+            #[cfg(feature = "unwind")]
+            {
+                if self.config.native {
+                    if let Some(native) = self.native.as_mut() {
+                        if let Some(thread_id) = trace.os_thread_id {
+                            let os_thread = remoteprocess::Thread::new(thread_id as Tid)?;
+                            trace.frames =
+                                native.merge_native_thread(&trace.frames, &os_thread)?;
+                        }
+                    }
+                }
+            }
+
+            for frame in &mut trace.frames {
+                frame.short_filename = self.shorten_filename(&frame.filename);
+                if let Some(locals) = frame.locals.as_mut() {
+                    let max_length = (128 * self.config.dump_locals) as isize;
+                    for local in locals {
+                        local.repr = Some(
+                            format_var(&self.process, &self.version, local.addr, max_length)
+                                .unwrap_or_else(|_| "?".to_owned()),
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/src/python_threading.rs
+++ b/src/python_threading.rs
@@ -23,9 +23,323 @@ pub fn thread_names_from_interpreter<I: InterpreterState, P: ProcessMemory>(
     let modules: *const I::Object = process
         .copy_pointer(modules_ptr_ptr)
         .context("Failed to copy modules PyObject")?;
+    thread_names_from_modules::<I, P>(modules as usize, process, version)
+}
+
+/// Returns a hashmap of threadid: threadname, by inspecting the '_active' variable in the
+/// 'threading' module.
+fn _thread_name_lookup<I: InterpreterState>(
+    spy: &PythonSpy,
+) -> Result<HashMap<u64, String>, Error> {
+    thread_names_from_interpreter::<I, Process>(spy.interpreter_address, &spy.process, &spy.version)
+}
+
+// try getting the threadnames, but don't sweat it if we can't. Since this relies on dictionary
+// processing we only handle py3.6+ right now, and this doesn't work at all if the
+// threading module isn't imported in the target program
+pub fn thread_name_lookup(process: &PythonSpy) -> Option<HashMap<u64, String>> {
+    let err = match process.version {
+        Version {
+            major: 3, minor: 6, ..
+        } => _thread_name_lookup::<v3_6_6::_is>(process),
+        Version {
+            major: 3, minor: 7, ..
+        } => _thread_name_lookup::<v3_7_0::_is>(process),
+        Version {
+            major: 3, minor: 8, ..
+        } => _thread_name_lookup::<v3_8_0::_is>(process),
+        Version {
+            major: 3, minor: 9, ..
+        } => _thread_name_lookup::<v3_9_5::_is>(process),
+        Version {
+            major: 3,
+            minor: 10,
+            ..
+        } => _thread_name_lookup::<v3_10_0::_is>(process),
+        Version {
+            major: 3,
+            minor: 11,
+            ..
+        } => _thread_name_lookup::<v3_11_0::_is>(process),
+        Version {
+            major: 3,
+            minor: 12,
+            ..
+        } => _thread_name_lookup::<v3_12_0::_is>(process),
+        Version {
+            major: 3,
+            minor: 13,
+            ..
+        } => _thread_name_lookup::<v3_13_0::_is>(process),
+        Version {
+            major: 3,
+            minor: 14,
+            ..
+        } => _thread_name_lookup_via_offsets(process),
+        _ => return None,
+    };
+    if let Err(ref e) = err {
+        warn!("thread_name_lookup: {:?}", e);
+    }
+    err.ok()
+}
+
+/// Fully offset-based thread name lookup for 3.14+ (handles both GIL-enabled and free-threaded).
+fn _thread_name_lookup_via_offsets(spy: &PythonSpy) -> Result<HashMap<u64, String>, Error> {
+    use crate::offset_stack_trace::{iter_dict_via_offsets, read_unicode_string};
+
+    let offsets = spy
+        .debug_offsets
+        .as_ref()
+        .ok_or_else(|| anyhow::format_err!("debug offsets not available"))?;
+
+    let modules_addr: usize = spy.process.copy_struct(
+        spy.interpreter_address + offsets.interp_imports_modules as usize,
+    )?;
+
+    let modules_entries = iter_dict_via_offsets(&spy.process, modules_addr, offsets)?;
+
+    // Discover type object field offsets from the first module in sys.modules.
+    let type_offsets = modules_entries
+        .first()
+        .and_then(|&(_, v)| discover_type_offsets(&spy.process, v, offsets).ok())
+        .unwrap_or(TypeOffsets {
+            tp_dictoffset: 0,
+            tp_basicsize: offsets.type_object_tp_name + std::mem::size_of::<usize>() as u64,
+            ht_cached_keys: 0,
+        });
 
     let mut ret = HashMap::new();
-    for entry in DictIterator::from(process, version, modules as usize)? {
+    for (key, value) in modules_entries {
+        let module_name = read_unicode_string(&spy.process, key, offsets)?;
+        if module_name != "threading" {
+            continue;
+        }
+
+        let module_dict = read_object_dict(&spy.process, value, offsets, &type_offsets)?;
+        if module_dict == 0 {
+            continue;
+        }
+
+        let module_dict_entries = iter_dict_via_offsets(&spy.process, module_dict, offsets)?;
+        info!("threading module dict: {} entries", module_dict_entries.len());
+        for (key, value) in module_dict_entries {
+            let name = read_unicode_string(&spy.process, key, offsets)?;
+            if name != "_active" {
+                continue;
+            }
+
+            for (key, value) in iter_dict_via_offsets(&spy.process, value, offsets)? {
+                let (threadid, _) = crate::offset_stack_trace::read_long_via_offsets(
+                    &spy.process,
+                    offsets,
+                    key,
+                )?;
+
+                let thread_type_addr =
+                    crate::debug_offsets::read_ptr(&spy.process, value, offsets.pyobject_ob_type)?;
+                let thread_dict =
+                    read_object_dict(&spy.process, value, offsets, &type_offsets)?;
+                if thread_dict != 0 {
+                    for (k, v) in iter_dict_via_offsets(&spy.process, thread_dict, offsets)? {
+                        let varname = read_unicode_string(&spy.process, k, offsets)?;
+                        if varname == "_name" {
+                            let threadname = read_unicode_string(&spy.process, v, offsets)?;
+                            ret.insert(threadid as u64, threadname);
+                            break;
+                        }
+                    }
+                } else {
+                    // Dict not materialized — try inline values
+                    let name_addr = read_inline_attr(
+                        &spy.process,
+                        value,
+                        "_name",
+                        thread_type_addr,
+                        offsets,
+                        &type_offsets,
+                    )?;
+                    if name_addr != 0 {
+                        if let Ok(threadname) = read_unicode_string(&spy.process, name_addr, offsets) {
+                            ret.insert(threadid as u64, threadname);
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        break;
+    }
+    Ok(ret)
+}
+
+/// Discovered offsets within PyTypeObject/PyHeapTypeObject that aren't in _Py_DebugOffsets.
+struct TypeOffsets {
+    tp_dictoffset: u64,
+    tp_basicsize: u64,
+    ht_cached_keys: u64,
+}
+
+/// Compute PyTypeObject field offsets that aren't in _Py_DebugOffsets.
+///
+/// These offsets are derived from the debug offsets plus known invariants:
+///
+/// - tp_basicsize immediately follows tp_name in PyTypeObject.
+/// - tp_dictoffset is discovered by scanning a module type for
+///   tp_dictoffset == pyobject_size (since PyModuleObject has md_dict
+///   right after its PyObject header).
+/// - ht_cached_keys uses the 3.13 bindgen offset (GIL-enabled layout is
+///   identical between 3.13 and 3.14), adjusted for free-threaded builds
+///   by the PyObject header size delta from _Py_DebugOffsets.pyobject.size.
+fn discover_type_offsets<P: ProcessMemory>(
+    process: &P,
+    module_obj_addr: usize,
+    offsets: &crate::debug_offsets::DebugOffsets,
+) -> Result<TypeOffsets, anyhow::Error> {
+    use crate::debug_offsets::read_ptr;
+
+    let ptr_size = std::mem::size_of::<usize>();
+    let type_addr = read_ptr(process, module_obj_addr, offsets.pyobject_ob_type)?;
+
+    // tp_basicsize immediately follows tp_name in PyTypeObject
+    let tp_basicsize = offsets.type_object_tp_name + ptr_size as u64;
+
+    // tp_dictoffset: scan for pyobject_size (module's tp_dictoffset == pyobject_size)
+    let expected_dictoffset = offsets.pyobject_size;
+    let scan_size = (offsets.type_object_tp_flags + 256) as usize;
+    let type_buf = process.copy(type_addr, scan_size)?;
+    let start = offsets.type_object_tp_flags as usize + ptr_size;
+    let mut tp_dictoffset = 0u64;
+    for off in (start..type_buf.len().saturating_sub(ptr_size - 1)).step_by(ptr_size) {
+        let val = usize::from_ne_bytes(type_buf[off..off + ptr_size].try_into().unwrap());
+        if val as u64 == expected_dictoffset {
+            tp_dictoffset = off as u64;
+            break;
+        }
+    }
+
+    // ht_cached_keys: use the 3.13 bindgen offset (correct for GIL-enabled 3.14 —
+    // PyHeapTypeObject layout is identical between 3.13 and 3.14 GIL-enabled).
+    // For free-threaded builds, adjust by the PyObject header size delta, since
+    // PyObject_VAR_HEAD at the root of PyTypeObject shifts all subsequent fields.
+    let gil_offset = std::mem::offset_of!(
+        crate::python_bindings::v3_13_0::PyHeapTypeObject,
+        ht_cached_keys
+    ) as u64;
+    let ht_cached_keys = if offsets.free_threaded {
+        // The GIL-enabled PyObject is 16 bytes; free-threaded is larger.
+        // Every field in PyTypeObject/PyHeapTypeObject shifts by the delta.
+        let pyobject_delta = offsets.pyobject_size - 16;
+        gil_offset + pyobject_delta
+    } else {
+        gil_offset
+    };
+
+    Ok(TypeOffsets {
+        tp_dictoffset,
+        tp_basicsize,
+        ht_cached_keys,
+    })
+}
+
+/// Read an object's __dict__ using debug offsets.
+/// Handles: managed dicts, inline values, and legacy tp_dictoffset.
+fn read_object_dict<P: ProcessMemory>(
+    process: &P,
+    obj_addr: usize,
+    offsets: &crate::debug_offsets::DebugOffsets,
+    type_offsets: &TypeOffsets,
+) -> Result<usize, anyhow::Error> {
+    use crate::debug_offsets::read_ptr;
+
+    let type_addr = read_ptr(process, obj_addr, offsets.pyobject_ob_type)?;
+    let flags = read_ptr(process, type_addr, offsets.type_object_tp_flags)?;
+
+    if flags & PY_TPFLAGS_MANAGED_DICT != 0 {
+        let ptr_size = std::mem::size_of::<usize>();
+        let managed_offset: isize = if offsets.free_threaded { -1 } else { -3 };
+        let dict_ptr_addr = (obj_addr as isize + managed_offset * ptr_size as isize) as usize;
+        let dict_addr: usize = process.copy_struct(dict_ptr_addr)?;
+        Ok(dict_addr)
+    } else if type_offsets.tp_dictoffset != 0 {
+        let dictoffset: isize =
+            process.copy_struct(type_addr + type_offsets.tp_dictoffset as usize)?;
+        if dictoffset == 0 {
+            return Ok(0);
+        }
+        let dict_addr: usize = process.copy_struct((obj_addr as isize + dictoffset) as usize)?;
+        Ok(dict_addr)
+    } else {
+        Ok(0)
+    }
+}
+
+/// Read an object's attribute from inline values (when managed dict is null).
+/// Returns the value of the named attribute, or 0 if not found.
+fn read_inline_attr<P: ProcessMemory>(
+    process: &P,
+    obj_addr: usize,
+    attr_name: &str,
+    type_addr: usize,
+    offsets: &crate::debug_offsets::DebugOffsets,
+    type_offsets: &TypeOffsets,
+) -> Result<usize, anyhow::Error> {
+    use crate::debug_offsets::read_ptr;
+
+    if type_offsets.ht_cached_keys == 0 || type_offsets.tp_basicsize == 0 {
+        return Ok(0);
+    }
+
+    let tp_basicsize: usize = process.copy_struct(type_addr + type_offsets.tp_basicsize as usize)?;
+    let ht_cached_keys: usize =
+        process.copy_struct(type_addr + type_offsets.ht_cached_keys as usize)?;
+    if ht_cached_keys == 0 {
+        return Ok(0);
+    }
+
+    let keys: crate::python_bindings::v3_12_0::PyDictKeysObject =
+        process.copy_struct(ht_cached_keys)?;
+    let entries_addr =
+        ht_cached_keys + (1 << keys.dk_log2_index_bytes) + std::mem::size_of_val(&keys);
+
+    let ptr_size = std::mem::size_of::<usize>();
+    // Inline values start after the object + _dictvalues header.
+    // _dictvalues has a 4-byte header (capacity, size, embedded, valid),
+    // padded to pointer alignment (8 bytes on 64-bit).
+    // See cpython/Include/internal/pycore_dict.h struct _dictvalues.
+    let dictvalues_header = std::mem::size_of::<usize>(); // 4 bytes padded to ptr alignment
+    let values_addr = obj_addr + tp_basicsize + dictvalues_header;
+
+    for index in 0..keys.dk_nentries as usize {
+        let entry_size = if keys.dk_kind == 0 { 3 * ptr_size } else { 2 * ptr_size };
+        let entry_addr = entries_addr + index * entry_size;
+        let key_ptr = if keys.dk_kind == 0 {
+            read_ptr(process, entry_addr + ptr_size, 0)?
+        } else {
+            read_ptr(process, entry_addr, 0)?
+        };
+        if key_ptr == 0 {
+            continue;
+        }
+        if let Ok(name) = crate::offset_stack_trace::read_unicode_string(process, key_ptr, offsets)
+        {
+            if name == attr_name {
+                let val: usize = process.copy_struct(values_addr + index * ptr_size)?;
+                return Ok(val);
+            }
+        }
+    }
+    Ok(0)
+}
+
+/// Like thread_names_from_interpreter but takes the modules dict address directly.
+fn thread_names_from_modules<I: InterpreterState, P: ProcessMemory>(
+    modules_addr: usize,
+    process: &P,
+    version: &Version,
+) -> Result<HashMap<u64, String>, Error> {
+    let mut ret = HashMap::new();
+    for entry in DictIterator::from(process, version, modules_addr)? {
         let (key, value) = entry?;
         let module_name = copy_string(key as *const I::StringObject, process)?;
         if module_name == "threading" {
@@ -77,54 +391,4 @@ pub fn thread_names_from_interpreter<I: InterpreterState, P: ProcessMemory>(
         }
     }
     Ok(ret)
-}
-
-/// Returns a hashmap of threadid: threadname, by inspecting the '_active' variable in the
-/// 'threading' module.
-fn _thread_name_lookup<I: InterpreterState>(
-    spy: &PythonSpy,
-) -> Result<HashMap<u64, String>, Error> {
-    thread_names_from_interpreter::<I, Process>(spy.interpreter_address, &spy.process, &spy.version)
-}
-
-// try getting the threadnames, but don't sweat it if we can't. Since this relies on dictionary
-// processing we only handle py3.6+ right now, and this doesn't work at all if the
-// threading module isn't imported in the target program
-pub fn thread_name_lookup(process: &PythonSpy) -> Option<HashMap<u64, String>> {
-    let err = match process.version {
-        Version {
-            major: 3, minor: 6, ..
-        } => _thread_name_lookup::<v3_6_6::_is>(process),
-        Version {
-            major: 3, minor: 7, ..
-        } => _thread_name_lookup::<v3_7_0::_is>(process),
-        Version {
-            major: 3, minor: 8, ..
-        } => _thread_name_lookup::<v3_8_0::_is>(process),
-        Version {
-            major: 3, minor: 9, ..
-        } => _thread_name_lookup::<v3_9_5::_is>(process),
-        Version {
-            major: 3,
-            minor: 10,
-            ..
-        } => _thread_name_lookup::<v3_10_0::_is>(process),
-        Version {
-            major: 3,
-            minor: 11,
-            ..
-        } => _thread_name_lookup::<v3_11_0::_is>(process),
-        Version {
-            major: 3,
-            minor: 12,
-            ..
-        } => _thread_name_lookup::<v3_12_0::_is>(process),
-        Version {
-            major: 3,
-            minor: 13,
-            ..
-        } => _thread_name_lookup::<v3_13_0::_is>(process),
-        _ => return None,
-    };
-    err.ok()
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -16,7 +16,7 @@ impl Version {
     pub fn scan_bytes(data: &[u8]) -> Result<Version, Error> {
         lazy_static! {
             static ref RE: Regex = Regex::new(
-                r"((2|3)\.(3|4|5|6|7|8|9|10|11|12|13)\.(\d{1,2}))((a|b|c|rc)\d{1,2})?(\+(?:[0-9a-z-]+(?:[.][0-9a-z-]+)*)?)? (.{1,64})"
+                r"((2|3)\.(3|4|5|6|7|8|9|10|11|12|13|14)\.(\d{1,2}))((a|b|c|rc)\d{1,2})?(\+(?:[0-9a-z-]+(?:[.][0-9a-z-]+)*)?)? (.{1,64})"
             )
             .unwrap();
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -553,3 +553,336 @@ fn test_delayed_subprocess() {
         break;
     }
 }
+
+fn require_root_on_macos() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if unsafe { libc::geteuid() } != 0 {
+            return false;
+        }
+    }
+    true
+}
+
+fn assert_traces_equivalent(trait_traces: &[py_spy::StackTrace], offset_traces: &[py_spy::StackTrace]) {
+
+    assert_eq!(
+        trait_traces.len(),
+        offset_traces.len(),
+        "Thread count mismatch: trait={} offset={}",
+        trait_traces.len(),
+        offset_traces.len()
+    );
+
+    for (t_trace, o_trace) in trait_traces.iter().zip(offset_traces.iter()) {
+        assert_eq!(
+            t_trace.thread_id, o_trace.thread_id,
+            "Thread ID mismatch"
+        );
+        assert_eq!(
+            t_trace.os_thread_id, o_trace.os_thread_id,
+            "OS thread ID mismatch for thread {}",
+            t_trace.thread_id
+        );
+        assert_eq!(
+            t_trace.owns_gil, o_trace.owns_gil,
+            "GIL ownership mismatch for thread {}",
+            t_trace.thread_id
+        );
+        assert_eq!(
+            t_trace.frames.len(),
+            o_trace.frames.len(),
+            "Frame count mismatch for thread {}: trait={} offset={}.\n  trait frames: {:?}\n  offset frames: {:?}",
+            t_trace.thread_id,
+            t_trace.frames.len(),
+            o_trace.frames.len(),
+            t_trace.frames.iter().map(|f| format!("{}:{}", f.filename, f.name)).collect::<Vec<_>>(),
+            o_trace.frames.iter().map(|f| format!("{}:{}", f.filename, f.name)).collect::<Vec<_>>(),
+        );
+
+        for (i, (t_frame, o_frame)) in
+            t_trace.frames.iter().zip(o_trace.frames.iter()).enumerate()
+        {
+            assert_eq!(
+                t_frame.filename, o_frame.filename,
+                "Filename mismatch at frame {} of thread {}",
+                i, t_trace.thread_id
+            );
+            assert_eq!(
+                t_frame.name, o_frame.name,
+                "Function name mismatch at frame {} of thread {}",
+                i, t_trace.thread_id
+            );
+            assert_eq!(
+                t_frame.line, o_frame.line,
+                "Line number mismatch at frame {} ({}.{}) of thread {}",
+                i, t_frame.filename, t_frame.name, t_trace.thread_id
+            );
+            assert_eq!(
+                t_frame.is_entry, o_frame.is_entry,
+                "is_entry mismatch at frame {} of thread {}",
+                i, t_trace.thread_id
+            );
+        }
+    }
+}
+
+/// Run an offset-vs-trait oracle comparison with the process suspended so both
+/// paths see identical interpreter state.
+fn run_offset_oracle(runner: &mut TestRunner) {
+    if runner.spy.version.minor < 13 {
+        eprintln!(
+            "Skipping: Python {}.{} < 3.13",
+            runner.spy.version.major, runner.spy.version.minor
+        );
+        return;
+    }
+    // Suspend the process externally so both reads see the same state.
+    // Override blocking to NonBlocking so the internal get_stack_traces
+    // doesn't try to ptrace-attach (which would conflict with our lock).
+    let _lock = match runner.spy.process.lock() {
+        Ok(lock) => lock,
+        Err(e) => {
+            eprintln!("Skipping oracle test: cannot lock process ({})", e);
+            return;
+        }
+    };
+    runner.spy.config.blocking = py_spy::config::LockingStrategy::NonBlocking;
+    let trait_traces = runner.spy.get_stack_traces().unwrap();
+    let offset_traces = runner.spy.get_stack_traces_via_offsets().unwrap();
+    drop(_lock);
+    assert_traces_equivalent(&trait_traces, &offset_traces);
+}
+
+#[test]
+fn test_offset_oracle_longsleep() {
+    if !require_root_on_macos() {
+        return;
+    }
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/longsleep.py");
+    run_offset_oracle(&mut runner);
+}
+
+#[test]
+fn test_offset_oracle_busyloop() {
+    if !require_root_on_macos() {
+        return;
+    }
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/busyloop.py");
+    run_offset_oracle(&mut runner);
+}
+
+#[test]
+fn test_offset_oracle_threads() {
+    if !require_root_on_macos() {
+        return;
+    }
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/thread_names.py");
+    run_offset_oracle(&mut runner);
+}
+
+#[test]
+fn test_offset_oracle_recursive() {
+    if !require_root_on_macos() {
+        return;
+    }
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/recursive.py");
+    run_offset_oracle(&mut runner);
+}
+
+const PYTHON314: &str = "python3.14";
+
+fn python314_available() -> bool {
+    std::process::Command::new(PYTHON314)
+        .arg("--version")
+        .output()
+        .is_ok()
+}
+
+#[test]
+fn test_314_longsleep() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314);
+        return;
+    }
+    let child = ScriptRunner::new(PYTHON314, "./tests/scripts/longsleep.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &Config::default(), 20).unwrap();
+    assert_eq!(spy.version.minor, 14);
+
+    let traces = spy.get_stack_traces().unwrap();
+    assert_eq!(traces.len(), 1);
+    let trace = &traces[0];
+    assert_eq!(trace.frames[0].name, "longsleep");
+    assert!(trace.frames[0].filename.contains("longsleep.py"));
+    assert_eq!(trace.frames[0].line, 5);
+    assert_eq!(trace.frames[1].name, "<module>");
+}
+
+#[test]
+fn test_314_busyloop() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314);
+        return;
+    }
+    let child = ScriptRunner::new(PYTHON314, "./tests/scripts/busyloop.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &Config::default(), 20).unwrap();
+    assert_eq!(spy.version.minor, 14);
+
+    let traces = spy.get_stack_traces().unwrap();
+    assert!(!traces.is_empty());
+    assert!(traces[0].active);
+    // Verify we get valid frames with expected filenames
+    assert!(traces[0].frames.iter().any(|f| f.filename.contains("busyloop.py")));
+}
+
+#[test]
+fn test_314_threads() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314);
+        return;
+    }
+    let child = ScriptRunner::new(PYTHON314, "./tests/scripts/thread_names.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &Config::default(), 20).unwrap();
+    assert_eq!(spy.version.minor, 14);
+
+    let traces = spy.get_stack_traces().unwrap();
+    // thread_names.py creates 10 threads + main = 11
+    assert!(traces.len() >= 2, "Expected multiple threads, got {}", traces.len());
+}
+
+const PYTHON314T: &str = "python3.14t";
+
+fn python314t_available() -> bool {
+    std::process::Command::new(PYTHON314T)
+        .arg("--version")
+        .output()
+        .is_ok()
+}
+
+#[test]
+fn test_314t_longsleep() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314t_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314T);
+        return;
+    }
+    let child = ScriptRunner::new(PYTHON314T, "./tests/scripts/longsleep.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &Config::default(), 20).unwrap();
+    assert_eq!(spy.version.minor, 14);
+
+    let traces = spy.get_stack_traces().unwrap();
+    assert_eq!(traces.len(), 1);
+    let trace = &traces[0];
+    assert_eq!(trace.frames[0].name, "longsleep");
+    assert!(trace.frames[0].filename.contains("longsleep.py"));
+    assert_eq!(trace.frames[0].line, 5);
+    assert_eq!(trace.frames[1].name, "<module>");
+    // In free-threaded builds with GIL disabled, no thread owns the GIL
+    assert!(!trace.owns_gil);
+}
+
+#[test]
+fn test_314t_busyloop() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314t_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314T);
+        return;
+    }
+    let child = ScriptRunner::new(PYTHON314T, "./tests/scripts/busyloop.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &Config::default(), 20).unwrap();
+    assert_eq!(spy.version.minor, 14);
+
+    let traces = spy.get_stack_traces().unwrap();
+    assert!(!traces.is_empty());
+    assert!(traces[0].frames.iter().any(|f| f.filename.contains("busyloop.py")));
+}
+
+#[test]
+fn test_314t_threads() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314t_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314T);
+        return;
+    }
+    let child = ScriptRunner::new(PYTHON314T, "./tests/scripts/thread_names.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &Config::default(), 20).unwrap();
+    assert_eq!(spy.version.minor, 14);
+
+    let traces = spy.get_stack_traces().unwrap();
+    assert!(traces.len() >= 2, "Expected multiple threads, got {}", traces.len());
+    // No thread should own the GIL in a free-threaded build
+    for trace in &traces {
+        assert!(!trace.owns_gil, "Thread {} unexpectedly owns GIL in free-threaded build", trace.thread_id);
+    }
+}
+
+#[test]
+fn test_314t_thread_names() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314t_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314T);
+        return;
+    }
+    let config = Config {
+        include_idle: true,
+        ..Default::default()
+    };
+    let child = ScriptRunner::new(PYTHON314T, "./tests/scripts/thread_names.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &config, 20).unwrap();
+    assert_eq!(spy.version.minor, 14);
+
+    let traces = spy.get_stack_traces().unwrap();
+    assert_eq!(traces.len(), 11, "Expected 11 threads (main + 10 custom)");
+
+    let mut expected_threads: HashSet<String> =
+        (0..10).map(|n| format!("CustomThreadName-{}", n)).collect();
+    expected_threads.insert("MainThread".to_string());
+    let detected_threads: HashSet<String> = traces
+        .iter()
+        .filter_map(|trace| trace.thread_name.clone())
+        .collect();
+    assert_eq!(expected_threads, detected_threads);
+}
+
+#[test]
+fn test_314t_recursive() {
+    if !require_root_on_macos() {
+        return;
+    }
+    if !python314t_available() {
+        eprintln!("Skipping: {} not found in PATH", PYTHON314T);
+        return;
+    }
+    let child = ScriptRunner::new(PYTHON314T, "./tests/scripts/recursive.py");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut spy = PythonSpy::retry_new(child.id(), &Config::default(), 20).unwrap();
+
+    let traces = spy.get_stack_traces().unwrap();
+    assert!(!traces.is_empty());
+    assert!(traces[0].frames.len() >= 2, "Expected recursive frames");
+    assert!(traces[0].frames.iter().any(|f| f.name == "recurse"));
+}


### PR DESCRIPTION
Instead of generating version-specific bindgen struct bindings for 3.14, read interpreter state using field offsets from CPython's `_Py_DebugOffsets` metadata table (embedded at the start of `_PyRuntime`). This table, present since 3.13, provides offsets for all core interpreter structs -- `PyInterpreterState`, `PyThreadState`, `_PyInterpreterFrame`, `PyCodeObject`, and common Python object types -- allowing a profiler to read them without compile-time knowledge of their layouts.

The offset-based approach handles 3.14's key structural changes:

  - `_PyStackRef` tagged pointers replacing `PyObject*` in frame fields (extraction: `bits & !1`; null: `bits == 1`; tagged int: `bits & 3 == 3`)
  - `FRAME_OWNED_BY_CSTACK` renumbered from 3 to 4
  - Free-threaded `PyObject` header enlargement (16 -> 32 bytes)
  - Free-threaded `PyASCIIObject.state.interned` changed from a 2-bit bitfield to a full `unsigned char` (for atomic access), shifting kind/compact/ascii into the next byte
  - Thread-local bytecode (TLBC) in free-threaded builds, where `instr_ptr` may point into a per-thread copy rather than `co_code_adaptive`
  - Dict entry format change (`dk_kind==0` now uses a 3-field `KeyWithHash` entry instead of the legacy `PyDictKeyEntry`)
  - Inline values for object attributes (`Thread._name` is stored inline rather than in a materialized `__dict__`)

Feature parity with the trait-based path:

  - Stack traces with filenames, function names, and line numbers
  - GIL detection (including free-threaded builds where GIL is disabled)
  - Thread names (via offset-based dict iteration and inline value reading)
  - Local variable inspection (`--dump-locals`), including dict, list, tuple, string, int, float, and numpy scalar formatting
  - Native stack merging, active/idle detection, short filenames

Python 3.13 also uses the offset-based path (validated via oracle comparison tests against the trait-based path on identical frozen process state).

Performance: frame and thread state structs are bulk-read in single `process_vm_readv` / `mach_vm_read` calls via `StructBuf`, matching the trait-based path's existing behavior of ~2 struct reads per frame (frame + code object), plus string/linetable reads that both paths require.

The existing trait-based code path is unchanged for Python <=3.12. The 3.13 bindgen types (`v3_13_0`) are reused in a few places where `_Py_DebugOffsets` doesn't yet provide sufficient information:

  - `PyDictKeysObject` layout (no `PyObject` header, stable across builds)
  - `ht_cached_keys` offset in `PyHeapTypeObject` (derived from the 3.13 bindgen offset, adjusted by the `PyObject` header size delta for free-threaded builds)
  - `tp_dictoffset` within `PyTypeObject` (discovered at runtime by scanning a module type for a known value)

These workarounds are documented and will be unnecessary if python/cpython#146462 is resolved (adding `tp_dictoffset`, `tp_basicsize`, and `ht_cached_keys` to `_Py_DebugOffsets`).

Known limitations:

  - 32-bit platforms: inline value reading (`ht_cached_keys`) is not supported; thread names will be unavailable for 3.14 on 32-bit.
  - The `_dictvalues` header size (4 bytes padded to pointer alignment) and `MANAGED_DICT_OFFSET` (-1 or -3 * ptr_size depending on `Py_GIL_DISABLED`) are derived from CPython internals not exposed via `_Py_DebugOffsets`.
  - `PyCompactUnicodeObject` size is derived as `asciiobject_size + 2 * ptr_size` (for the `utf8_length` and `utf8` fields); `_Py_DebugOffsets` provides `asciiobject_size` but not `PyCompactUnicodeObject` size directly.