### PR TITLE
Fix BSS scan for when symbols aren't available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,11 +193,11 @@ jobs:
             3.8.0,
             3.8.18,
             3.9.0,
-            3.9.23,
+            3.9.25,
             3.10.0,
-            3.10.18,
+            3.10.20,
             3.11.0,
-            3.11.13,
+            3.11.15,
             3.12.0,
             3.12.1,
             3.12.2,
@@ -210,6 +210,8 @@ jobs:
             3.12.9,
             3.12.10,
             3.12.11,
+            3.12.12,
+            3.12.13,
             3.13.0,
             3.13.1,
             3.13.2,
@@ -218,76 +220,110 @@ jobs:
             3.13.5,
             3.13.6,
             3.13.7,
+            3.13.8,
+            3.13.9,
+            3.13.10,
+            3.13.11,
+            3.13.12,
+            3.13.13,
           ]
-        os: [ubuntu-22.04, macos-13, windows-latest, ubuntu-22.04-arm]
+        os: [ubuntu-22.04, macos-latest, windows-latest, ubuntu-22.04-arm]
         # some versions of python can't be tested on GHA with osx because of SIP:
         exclude:
+          - os: macos-latest
+            python-version: 3.6.7
           - os: ubuntu-22.04
             python-version: 3.6.7
           - os: ubuntu-22.04-arm
             python-version: 3.6.7
+          - os: macos-latest
+            python-version: 3.6.15
           - os: windows-latest
             python-version: 3.6.15
           - os: ubuntu-22.04
             python-version: 3.6.15
           - os: ubuntu-22.04-arm
             python-version: 3.6.15
+          - os: macos-latest
+            python-version: 3.7.1
           - os: ubuntu-22.04
             python-version: 3.7.1
           - os: ubuntu-22.04-arm
             python-version: 3.7.1
+          - os: macos-latest
+            python-version: 3.7.17
           - os: windows-latest
             python-version: 3.7.17
           - os: ubuntu-22.04-arm
             python-version: 3.7.17
+          - os: macos-latest
+            python-version: 3.8.0
           - os: ubuntu-22.04
             python-version: 3.8.0
           - os: ubuntu-22.04-arm
             python-version: 3.8.0
+          - os: macos-latest
+            python-version: 3.8.18
           - os: windows-latest
             python-version: 3.8.18
+          - os: macos-latest
+            python-version: 3.9.0
           - os: ubuntu-22.04
             python-version: 3.9.0
           - os: ubuntu-22.04-arm
             python-version: 3.9.0
+          - os: macos-latest
+            python-version: 3.9.25
           - os: windows-latest
-            python-version: 3.9.23
+            python-version: 3.9.25
+          - os: macos-latest
+            python-version: 3.10.0
           - os: ubuntu-22.04
             python-version: 3.10.0
           - os: ubuntu-22.04-arm
             python-version: 3.10.0
+          - os: macos-latest
+            python-version: 3.10.20
           - os: windows-latest
-            python-version: 3.10.18
-          - os: macos-13
-            python-version: 3.11.13
+            python-version: 3.10.20
+          - os: macos-latest
+            python-version: 3.11.15
           - os: windows-latest
-            python-version: 3.11.13
-          - os: macos-13
+            python-version: 3.11.15
+          - os: macos-latest
             python-version: 3.12.0
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.1
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.2
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.3
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.4
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.5
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.6
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.7
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.8
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.9
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.10
-          - os: macos-13
+          - os: macos-latest
             python-version: 3.12.11
           - os: windows-latest
             python-version: 3.12.11
+          - os: macos-latest
+            python-version: 3.12.12
+          - os: windows-latest
+            python-version: 3.12.12
+          - os: macos-latest
+            python-version: 3.12.13
+          - os: windows-latest
+            python-version: 3.12.13
 
     steps:
       - uses: actions/checkout@v5

--- a/ci/update_python_test_versions.py
+++ b/ci/update_python_test_versions.py
@@ -97,8 +97,8 @@ def update_python_test_versions():
     exclusions = []
     for v in versions:
         # if we don't have a python version for osx/windows skip
-        if ("darwin", "x64") not in platforms[v] or v.startswith("3.12"):
-            exclusions.append("          - os: macos-13\n")
+        if ("darwin", "arm64") not in platforms[v] or v.startswith("3.12"):
+            exclusions.append("          - os: macos-latest\n")
             exclusions.append(f"            python-version: {v}\n")
 
         if ("win32", "x64") not in platforms[v]:


### PR DESCRIPTION
On python v3.11 on OSX, we are seeing a CI failure on arm64 darwin runners. This seems to be related to not having _PyRuntime point to an accurate location on the version of python that GHA is picking up.

py-spy attempts to scan the BSS for valid python interpreters when it can't rely on symbols - but this was broken since we were always using the _PyRuntime symbol address instead of the detected interpreter address in the code related to the GIL detection. This affected profiling python v3.7 to v3.11.

Fix and update the mac osx gha runners so that this problem would be detected earlier