### PR TITLE
Fix release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,7 +15,7 @@ categories:
     labels:
       - "documentation"
   - title: "🧰 Maintenance"
-    label:
+    labels:
       - "chore"
       - "ci"
       - "dependencies"
@@ -36,6 +36,7 @@ version-resolver:
     labels:
       - "patch"
   default: patch
+
 template: |
   ## Changes
 


### PR DESCRIPTION
Since updating the release-drafter version in #836, we've been seeing failures on the release-drafter GHA runs. This seems to be caused by a typo in the config file - fix.