### PR TITLE
Show backtrace on errors when RUST_BACKTRACE=1 environment variable is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -509,12 +509,7 @@ fn main() {
             }
         }
 
-        eprintln!("Error: {err}");
-        for (i, suberror) in err.chain().enumerate() {
-            if i > 0 {
-                eprintln!("Reason: {suberror}");
-            }
-        }
+        eprintln!("Error: {:?}", err);
         std::process::exit(1);
     }
 }

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -45,7 +45,7 @@ class TestPyspy(unittest.TestCase):
             ]
             cmdline.extend(options or [])
             cmdline.extend(["--", sys.executable, script_name])
-            env = dict(os.environ, RUST_LOG="info")
+            env = dict(os.environ, RUST_LOG="info", RUST_BACKTRACE="1")
             subprocess.check_output(cmdline, env=env)
             with open(filename) as f:
                 profiles = json.load(f)


### PR DESCRIPTION
Show backtrace on errors when the RUST_BACKTRACE=1 environment variable is set. Also enable showing the back trace during the python integration tests to help debug in some intermittent errors on OSX CI.