### PR TITLE
Fix getting symbols from OSX universal binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,25 +283,13 @@ jobs:
           - os: windows-latest
             python-version: 3.10.20
           - os: macos-latest
-            python-version: 3.11.0
-          - os: macos-latest
             python-version: 3.11.15
           - os: windows-latest
             python-version: 3.11.15
           - os: macos-latest
-            python-version: 3.12.0
-          - os: macos-latest
             python-version: 3.12.13
           - os: windows-latest
             python-version: 3.12.13
-          - os: macos-latest
-            python-version: 3.14.0
-          - os: macos-latest
-            python-version: 3.14.1
-          - os: macos-latest
-            python-version: 3.14.2
-          - os: macos-latest
-            python-version: 3.14.3
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,6 +287,8 @@ jobs:
           - os: windows-latest
             python-version: 3.11.15
           - os: macos-latest
+            python-version: 3.12.0
+          - os: macos-latest
             python-version: 3.12.13
           - os: windows-latest
             python-version: 3.12.13

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,7 +1,7 @@
 # draft release notes with https://github.com/release-drafter/release-drafter
 name: Release Drafter
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:

--- a/ci/update_python_test_versions.py
+++ b/ci/update_python_test_versions.py
@@ -7,7 +7,7 @@ import re
 
 _VERSIONS_URL = "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"  # noqa
 
-_OSX_PYTHON_EXCLUSIONS = ["3.11.0", "3.12", "3.14.0", "3.14.1", "3.14.2", "3.14.3"]
+_OSX_PYTHON_EXCLUSIONS = []
 
 
 def parse_version(v):

--- a/ci/update_python_test_versions.py
+++ b/ci/update_python_test_versions.py
@@ -7,7 +7,7 @@ import re
 
 _VERSIONS_URL = "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"  # noqa
 
-_OSX_PYTHON_EXCLUSIONS = []
+_OSX_PYTHON_EXCLUSIONS = [3.12]
 
 
 def parse_version(v):

--- a/ci/update_python_test_versions.py
+++ b/ci/update_python_test_versions.py
@@ -7,7 +7,7 @@ import re
 
 _VERSIONS_URL = "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"  # noqa
 
-_OSX_PYTHON_EXCLUSIONS = [3.12]
+_OSX_PYTHON_EXCLUSIONS = ["3.12"]
 
 
 def parse_version(v):

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -27,6 +27,38 @@ impl BinaryInfo {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn get_mach_cpu_type() -> goblin::mach::cputype::CpuType {
+    let is_arm: i32 = 0;
+    let size: usize = std::mem::size_of_val(&is_arm);
+    unsafe {
+        let name = std::ffi::CString::new("hw.optional.arm64").expect("CString::new failed");
+        let ret = libc::sysctlbyname(
+            name.as_ptr() as *const i8,
+            &is_arm as *const _ as *mut _,
+            &size as *const _ as *mut _,
+            std::ptr::null_mut(),
+            0,
+        );
+        if ret != 0 {
+            // if the `hw.optional.arm64` key doesn't exist, its likely that we are running on an
+            // older x86_64 based intel mac
+            warn!("failed to call 'libc::sysctlbyname(\"hw.optional.arm64\",...' - assume running on x86_64 ");
+            return goblin::mach::cputype::CPU_TYPE_X86_64;
+        }
+    }
+    if is_arm == 1 {
+        goblin::mach::cputype::CPU_TYPE_ARM64
+    } else {
+        goblin::mach::cputype::CPU_TYPE_X86_64
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn get_mach_cpu_type() -> goblin::mach::cputype::CpuType {
+    goblin::mach::cputype::CPU_TYPE_ANY
+}
+
 /// Uses goblin to parse a binary file, returns information on symbols/bss/adjusted offset etc
 pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo, Error> {
     let offset = addr;
@@ -36,6 +68,10 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
     // Read in the filename
     let file = File::open(filename)?;
     let buffer = unsafe { Mmap::map(&file)? };
+
+    // for OSX, we could be running under rosetta (is compiled for x86_64, but running under
+    // arm64). check the currently running cpu type rather than relying on compile time flags
+    let mach_cputype = get_mach_cpu_type();
 
     // Use goblin to parse the binary
     match Object::parse(&buffer)? {
@@ -47,7 +83,7 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                     let arch = fat
                         .iter_arches()
                         .find(|arch| match arch {
-                            Ok(arch) => arch.is_64(),
+                            Ok(arch) => arch.is_64() && arch.cputype() == mach_cputype,
                             Err(_) => false,
                         })
                         .ok_or_else(|| {


### PR DESCRIPTION
When profiling on OSX, the python binary could be a universal binary containing both x86_64 and aarch64 code. We didn't account for this when loading, which caused us to read incorrect values for symbols - since we could be getting the address for the x86_64 PyRuntime symbol when we need the aarch64 PyRuntime address.  Fix.