### PR TITLE
 Gate CLI dependencies behind optional `cli` feature flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
           python-version: 3.9
       - name: Build
         run: cargo build --release --verbose --examples
+      - name: Build library
+        run: cargo build --release --verbose --lib --no-default-features
       - uses: actions/setup-python@v6
         with:
           python-version: 3.9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [features]
+default = ["cli"]
+cli = ["dep:clap", "dep:clap_complete", "dep:console", "dep:ctrlc", "dep:indicatif", "dep:inferno", "dep:env_logger"]
 unwind = ["remoteprocess/unwind"]
 
 [package]
@@ -11,19 +13,24 @@ description = "Sampling profiler for Python programs "
 readme = "README.md"
 exclude = ["images/*", "test_programs/*"]
 license = "MIT"
-build="build.rs"
-edition="2021"
+build = "build.rs"
+edition = "2021"
+
+[[bin]]
+name = "py-spy"
+path = "src/main.rs"
+required-features = ["cli"]
 
 [dependencies]
 anyhow = "1"
-clap = {version="4.6.1", features=["wrap_help", "cargo", "derive"]}
-clap_complete="4.6.1"
-console = "0.16"
-ctrlc = "3"
-indicatif = "0.18"
-env_logger = "0.11"
+clap = { version = "4.6.1", features = ["wrap_help", "cargo", "derive"], optional = true }
+clap_complete = { version = "4.6.1", optional = true }
+console = { version = "0.16", optional = true }
+ctrlc = { version = "3", optional = true }
+indicatif = { version = "0.18", optional = true }
+env_logger = { version = "0.11", optional = true }
+inferno = { version = "0.12.6", optional = true }
 goblin = "0.10.5"
-inferno = "0.12.6"
 lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
@@ -35,7 +42,7 @@ page_size = "0.6.0"
 proc-maps = "0.4.0"
 memmap2 = "0.9.4"
 cpp_demangle = "0.5"
-serde = {version="1.0", features=["rc"]}
+serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.9"
@@ -50,4 +57,4 @@ py-spy-testdata = "0.1.0"
 termios = "0.3.3"
 
 [target.'cfg(windows)'.dependencies]
-winapi = {version = "0.3", features = ["errhandlingapi", "winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv" ]}
+winapi = { version = "0.3", features = ["errhandlingapi", "winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "cli")]
 use clap::builder::{styling::AnsiColor, EnumValueParser, Styles};
+#[cfg(feature = "cli")]
 use clap::{
     crate_description, crate_name, crate_version, value_parser, Arg, ArgAction, Command, ValueEnum,
 };
@@ -62,7 +64,8 @@ pub struct Config {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(ValueEnum, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "cli", derive(ValueEnum))]
 pub enum FileFormat {
     flamegraph,
     raw,
@@ -70,6 +73,7 @@ pub enum FileFormat {
     chrometrace,
 }
 
+#[cfg(feature = "cli")]
 impl std::str::FromStr for FileFormat {
     type Err = String;
 
@@ -135,6 +139,7 @@ impl Default for Config {
     }
 }
 
+#[cfg(feature = "cli")]
 impl Config {
     /// Uses clap to set config options from commandline arguments
     pub fn from_commandline() -> Config {
@@ -503,6 +508,7 @@ impl Config {
     }
 }
 
+#[cfg(feature = "cli")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,11 @@ extern crate log;
 
 pub mod binary_parser;
 pub mod config;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "cli"))]
 pub mod coredump;
 #[cfg(feature = "unwind")]
 mod cython;
+#[cfg(feature = "cli")]
 pub mod dump;
 #[cfg(feature = "unwind")]
 mod native_stack_trace;


### PR DESCRIPTION
py-spy is used as a library in pyroscope-rs where CLI dependencies
(clap, inferno, console, ctrlc, indicatif, env_logger) are unnecessary.
This adds a `cli` feature flag (enabled by default) that guards all
CLI-only dependencies, allowing library consumers to opt out with
`default-features = false`.

  Changes:
  - Make clap, clap_complete, console, ctrlc, indicatif, inferno, and
    env_logger optional dependencies gated by the `cli` feature
  - Add `[[bin]]` with `required-features = ["cli"]` so the binary is
    skipped when building without CLI
  - Gate clap-dependent code in config.rs (ArgEnum derive, from_commandline,
    from_args, CLI tests) behind cli feature
  - Add CI step to build library without cli feature
  - Gate coredump and dump modiles behind cli feature