### PR TITLE
Add objects subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ can be installed with ```apk add py-spy --update-cache --repository http://dl-3.
 ## Usage
 
 py-spy works from the command line and takes either the PID of the program you want to sample from
-or the command line of the python program you want to run. py-spy has three subcommands
-```record```, ```top``` and ```dump```:
+or the command line of the python program you want to run. py-spy has four subcommands
+```record```, ```top```, ```dump``` and ```objects```:
 
 ### record
 
@@ -94,6 +94,25 @@ console:
 This is useful for the case where you just need a single call stack to figure out where your
 python program is hung on. This command also has the ability to print out the local variables
 associated with each stack frame by setting the ```--locals``` flag.
+
+### objects
+
+py-spy has limited support for object introspection (available for 3.9+). Objects must be
+user/library-defined and must be reachable by the GC. `--objectpath` can be used for filtering
+by specifying a type name followed by one or more attributes that will be walked.
+
+```bash
+# Print all GC-reachable objects
+py-spy objects --pid 12345
+# Print value attribute of all objects of type Foo
+py-spy objects --pid 12345 --objectpath Foo.value
+# Print url attribute found in config attribute of all objects of type Foo
+py-spy objects --pid 12345 --objectpath Foo.config.url
+# Print all dicts
+py-spy objects --pid 12345 --objectpath dict
+# Inspect a core dump instead of live process
+py-spy objects -c core.elf --objectpath dict
+```
 
 ## Frequently Asked Questions
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,8 @@ pub struct Config {
     pub refresh_seconds: f64,
     #[doc(hidden)]
     pub core_filename: Option<String>,
+    #[doc(hidden)]
+    pub object_path: Option<String>,
 }
 
 #[allow(non_camel_case_types)]
@@ -135,6 +137,7 @@ impl Default for Config {
             lineno: LineNo::LastInstruction,
             refresh_seconds: 1.0,
             core_filename: None,
+            object_path: None,
         }
     }
 }
@@ -331,6 +334,26 @@ impl Config {
                 .action(ArgAction::SetTrue))
             .arg(subprocesses.clone());
 
+        let objects = Command::new("objects")
+            .about("Dumps objects for a target program to stdout")
+            .arg(
+                Arg::new("core")
+                    .short('c')
+                    .long("core")
+                    .help("Filename of coredump to display python objects from")
+                    .value_name("core")
+                    .action(ArgAction::Set),
+            )
+            .arg(
+                Arg::new("objectpath")
+                    .long("objectpath")
+                    .help("Name of a type or path of an attribute, e.g., MyType._history")
+                    .value_name("objectpath")
+                    .action(ArgAction::Set),
+            )
+            .arg(subprocesses.clone())
+            .arg(pid.clone().required_unless_present("core"));
+
         let completions = Command::new("completions")
             .about("Generate shell completions")
             .hide(true)
@@ -353,6 +376,8 @@ impl Config {
         let top = top.arg(nonblocking.clone());
         #[cfg(not(target_os = "freebsd"))]
         let dump = dump.arg(nonblocking.clone());
+        #[cfg(not(target_os = "freebsd"))]
+        let objects = objects.arg(nonblocking.clone());
 
         let styles = Styles::styled()
             .header(AnsiColor::Yellow.on_default())
@@ -370,6 +395,7 @@ impl Config {
             .subcommand(record)
             .subcommand(top)
             .subcommand(dump)
+            .subcommand(objects)
             .subcommand(completions);
         let matches = app.clone().try_get_matches_from(args)?;
         debug!("Command line args: {:?}", matches);
@@ -379,7 +405,11 @@ impl Config {
         let (subcommand, matches) = matches.subcommand().unwrap();
 
         // Check if `--native` was used on an unsupported platform
-        if subcommand != "completions" && !cfg!(feature = "unwind") && matches.get_flag("native") {
+        if subcommand != "completions"
+            && subcommand != "objects"
+            && !cfg!(feature = "unwind")
+            && matches.get_flag("native")
+        {
             eprintln!(
                 "Collecting stack traces from native extensions (`--native`) is not supported on your platform."
             );
@@ -425,6 +455,10 @@ impl Config {
                     config.core_filename = matches.get_one("core").cloned();
                 }
             }
+            "objects" => {
+                config.core_filename = matches.get_one("core").cloned();
+                config.object_path = matches.get_one("objectpath").cloned();
+            }
             "completions" => {
                 let shell = matches.get_one::<clap_complete::Shell>("shell").unwrap();
                 let app_name = app.get_name().to_string();
@@ -457,7 +491,9 @@ impl Config {
             }
         });
 
-        config.full_filenames = matches.get_flag("full_filenames");
+        if subcommand != "objects" {
+            config.full_filenames = matches.get_flag("full_filenames");
+        }
         if cfg!(feature = "unwind") {
             config.native = matches.get_flag("native");
         }

--- a/src/coredump.rs
+++ b/src/coredump.rs
@@ -14,12 +14,13 @@ use remoteprocess::ProcessMemory;
 use crate::binary_parser::{parse_binary, BinaryInfo};
 use crate::config::Config;
 use crate::dump::print_trace;
+use crate::obj_walk::{get_object_attribute, walk_gc};
 use crate::python_bindings::{
     v2_7_15, v3_10_0, v3_11_0, v3_12_0, v3_13_0, v3_14_0, v3_3_7, v3_5_5, v3_6_6, v3_7_0, v3_8_0,
     v3_9_5,
 };
 use crate::python_data_access::format_variable;
-use crate::python_interpreters::InterpreterState;
+use crate::python_interpreters::{HasGcGenerations, InterpreterState};
 use crate::python_process_info::{
     get_interpreter_address, get_python_version, get_threadstate_address, is_python_lib,
     ContainsAddr, PythonProcessInfo,
@@ -394,6 +395,81 @@ impl PythonCoreDump {
         for trace in traces.iter().rev() {
             print_trace(trace, false);
         }
+        Ok(())
+    }
+
+    pub fn print_objects(&self, config: &Config) -> Result<(), Error> {
+        match self.version {
+            Version {
+                major: 3, minor: 9, ..
+            } => self._print_objects::<v3_9_5::_is>(config),
+            Version {
+                major: 3,
+                minor: 10,
+                ..
+            } => self._print_objects::<v3_10_0::_is>(config),
+            Version {
+                major: 3,
+                minor: 11,
+                ..
+            } => self._print_objects::<v3_11_0::_is>(config),
+            Version {
+                major: 3,
+                minor: 12,
+                ..
+            } => self._print_objects::<v3_12_0::_is>(config),
+            Version {
+                major: 3,
+                minor: 13,
+                ..
+            } => self._print_objects::<v3_13_0::_is>(config),
+            Version {
+                major: 3,
+                minor: 14,
+                ..
+            } => self._print_objects::<v3_14_0::_is>(config),
+            _ => Err(format_err!(
+                "Unsupported version of Python: {}",
+                self.version
+            )),
+        }
+    }
+
+    fn _print_objects<I>(&self, config: &Config) -> Result<(), Error>
+    where
+        I: HasGcGenerations,
+    {
+        let (type_name, attrs): (Option<&str>, Vec<&str>) = match config.object_path.as_deref() {
+            Some(s) => {
+                let mut parts = s.split('.');
+                let first = parts.next();
+                let rest = parts.collect();
+                (first, rest)
+            }
+            None => (None, Vec::new()),
+        };
+
+        let objects = walk_gc::<I, CoreDump>(self.interpreter_address, type_name, &self.core)?;
+        println!("Found {} object(s)", objects.len());
+
+        if !attrs.is_empty() {
+            for obj in objects {
+                println!("<{} at 0x{:x}>:", type_name.unwrap(), obj);
+                match get_object_attribute::<I, CoreDump>(obj, &attrs, &self.core, &self.version) {
+                    Ok(attr) => println!("{}", attr),
+                    Err(err) => println!("{}", err),
+                }
+            }
+        } else {
+            for obj in objects {
+                if let Ok(formatted) =
+                    format_variable::<I, CoreDump>(&self.core, &self.version, obj, 200)
+                {
+                    println!("{}", formatted);
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod cython;
 pub mod dump;
 #[cfg(feature = "unwind")]
 mod native_stack_trace;
+mod obj_walk;
 mod python_bindings;
 mod python_data_access;
 mod python_interpreters;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod dump;
 mod flamegraph;
 #[cfg(feature = "unwind")]
 mod native_stack_trace;
+mod obj_walk;
 mod python_bindings;
 mod python_data_access;
 mod python_interpreters;
@@ -371,6 +372,10 @@ fn run_spy_command(pid: remoteprocess::Pid, config: &config::Config) -> Result<(
         "dump" => {
             dump::print_traces(pid, config, None)?;
         }
+        "objects" => {
+            let process = python_spy::PythonSpy::new(pid, config)?;
+            process.print_objects()?;
+        }
         "record" => {
             record_samples(pid, config)?;
         }
@@ -401,8 +406,18 @@ fn pyspy_main() -> Result<(), Error> {
     {
         if let Some(ref core_filename) = config.core_filename {
             let core = coredump::PythonCoreDump::new(std::path::Path::new(&core_filename))?;
-            let traces = core.get_stack(&config)?;
-            return core.print_traces(&traces, &config);
+            match config.command.as_ref() {
+                "dump" => {
+                    let traces = core.get_stack(&config)?;
+                    return core.print_traces(&traces, &config);
+                }
+                "objects" => {
+                    return core.print_objects(&config);
+                }
+                _ => {
+                    return Err(format_err!("Unknown command {}", config.command));
+                }
+            }
         }
     }
 

--- a/src/obj_walk.rs
+++ b/src/obj_walk.rs
@@ -1,0 +1,127 @@
+use anyhow::{Context, Error, Result};
+
+use remoteprocess::ProcessMemory;
+
+use crate::python_data_access::{
+    copy_string, format_variable, DictIterator, PY_TPFLAGS_MANAGED_DICT,
+};
+use crate::python_interpreters::{GcHead, HasGcGenerations, InterpreterState, Object, TypeObject};
+use crate::version::Version;
+
+pub fn walk_gc<I, P>(addr: usize, type_name: Option<&str>, process: &P) -> Result<Vec<usize>, Error>
+where
+    I: HasGcGenerations,
+    P: ProcessMemory,
+{
+    let mut ret = Vec::new();
+
+    for gen in I::gc_generations(addr) {
+        let head_addr = I::generation_head_addr(gen);
+        let mut gc: I::GcHead = process
+            .copy_pointer(head_addr)
+            .context("Failed to copy gen gc head")?;
+        let mut gc_addr = gc.next();
+
+        while gc_addr as *const _ != head_addr as *const _ {
+            gc = process
+                .copy_pointer(gc_addr)
+                .context("Failed to copy gchead")?;
+
+            let obj_addr = gc.obj_addr(gc_addr as usize);
+
+            let should_add = match type_name {
+                Some(name) => isinstance::<I, P>(obj_addr, name, process).unwrap_or(false),
+                None => true,
+            };
+            if should_add {
+                ret.push(obj_addr);
+            }
+
+            gc_addr = gc.next();
+        }
+    }
+    Ok(ret)
+}
+
+fn isinstance<I, P>(addr: usize, type_name: &str, process: &P) -> Result<bool, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let value: I::Object = process.copy_struct(addr)?;
+    let value_type = process.copy_pointer(value.ob_type())?;
+
+    // get the typename (truncating to 128 bytes if longer)
+    let max_type_len = 128;
+    let value_type_name = process.copy(value_type.name() as usize, max_type_len)?;
+    let length = value_type_name
+        .iter()
+        .position(|&x| x == 0)
+        .unwrap_or(max_type_len);
+    let value_type_name = std::str::from_utf8(&value_type_name[..length])?;
+
+    Ok(value_type_name == type_name)
+}
+
+pub fn get_object_attribute<I, P>(
+    addr: usize,
+    path: &Vec<&str>,
+    process: &P,
+    version: &Version,
+) -> Result<String, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    if path.len() == 0 {
+        return Err(format_err!(
+            "Path passed to get_object_attribute must not be empty"
+        ));
+    }
+
+    let mut cur_addr = addr;
+    for elem in path {
+        match resolve_attribute::<I, P>(cur_addr, elem, process, version) {
+            Ok(resolved) => cur_addr = resolved,
+            Err(e) => {
+                println!("Unable to resolve attribute: {}", e);
+                return Err(e);
+            }
+        };
+    }
+
+    format_variable::<I, P>(process, version, cur_addr, 16384)
+}
+
+pub fn resolve_attribute<I, P>(
+    addr: usize,
+    name: &str,
+    process: &P,
+    version: &Version,
+) -> Result<usize, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let value: I::Object = process.copy_struct(addr)?;
+    let value_type = process.copy_pointer(value.ob_type())?;
+
+    let flags = value_type.flags();
+    let dict_iter = if flags & PY_TPFLAGS_MANAGED_DICT != 0 {
+        DictIterator::from_managed_dict(process, version, addr, value.ob_type() as usize, flags)?
+    } else {
+        let dict_offset = value_type.dictoffset();
+        let dict_addr = (addr as isize + dict_offset) as usize;
+        let thread_dict_addr: usize = process.copy_struct(dict_addr)?;
+        DictIterator::from(process, version, thread_dict_addr)?
+    };
+
+    for i in dict_iter {
+        let (key, value) = i?;
+        let varname = copy_string(key as *const I::StringObject, process)?;
+        if varname == name {
+            return Ok(value);
+        }
+    }
+    Err(format_err!("Attribute {} not found", name))
+}

--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -468,6 +468,45 @@ where
             values.push(value);
         }
         format!("({})", values.join(", "))
+    } else if value_type_name == "set" {
+        // _setobject layout for fill,used,mask,table is the same from 2.7~3.15
+        let mask_ptr = addr + std::mem::size_of::<I::Object>() + 2 * std::mem::size_of::<usize>();
+        let table_ptr_ptr = addr + std::mem::size_of::<I::Object>() + 3 * std::mem::size_of::<usize>();
+
+        let mask: usize = process.copy_struct(mask_ptr)?;
+        let table_ptr: usize = process.copy_struct(table_ptr_ptr)?;
+        
+        let slots = mask + 1;
+        let key_ptr: usize;
+        let hash_ptr: usize;
+        if version.major == 2 || (version.major == 3 && version.minor < 4) {
+            // old versions have the hash first
+            hash_ptr = table_ptr;
+            key_ptr = table_ptr + std::mem::size_of::<usize>();
+        } else {
+            hash_ptr = table_ptr + std::mem::size_of::<usize>();
+            key_ptr = table_ptr;
+        }
+
+        let mut values = Vec::new();
+        let mut remaining = max_length - 2;
+        for i in 0..slots {
+            let hash: isize = process.copy_struct(hash_ptr + i * 2 * std::mem::size_of::<usize>())?;
+            if hash == 0 || hash == -1 {
+                // Unused slots are 0, Dummy slots are -1
+                continue;
+            }
+            let value_addr: *mut I::Object = process.copy_struct(key_ptr + i * 2 * std::mem::size_of::<usize>())?;
+            let value = format_variable::<I, P>(process, version, value_addr as usize, remaining)?;
+            remaining -= value.len() as isize + 2;
+            if remaining <= 5 {
+                values.push("...".to_owned());
+                break;
+            }
+            values.push(value);
+        }
+
+        format!("{{{}}}", values.join(", "))
     } else if value_type_name == "float" {
         let value =
             process.copy_pointer(addr as *const crate::python_bindings::v3_7_0::PyFloatObject)?;

--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -471,11 +471,12 @@ where
     } else if value_type_name == "set" {
         // _setobject layout for fill,used,mask,table is the same from 2.7~3.15
         let mask_ptr = addr + std::mem::size_of::<I::Object>() + 2 * std::mem::size_of::<usize>();
-        let table_ptr_ptr = addr + std::mem::size_of::<I::Object>() + 3 * std::mem::size_of::<usize>();
+        let table_ptr_ptr =
+            addr + std::mem::size_of::<I::Object>() + 3 * std::mem::size_of::<usize>();
 
         let mask: usize = process.copy_struct(mask_ptr)?;
         let table_ptr: usize = process.copy_struct(table_ptr_ptr)?;
-        
+
         let slots = mask + 1;
         let key_ptr: usize;
         let hash_ptr: usize;
@@ -491,12 +492,14 @@ where
         let mut values = Vec::new();
         let mut remaining = max_length - 2;
         for i in 0..slots {
-            let hash: isize = process.copy_struct(hash_ptr + i * 2 * std::mem::size_of::<usize>())?;
+            let hash: isize =
+                process.copy_struct(hash_ptr + i * 2 * std::mem::size_of::<usize>())?;
             if hash == 0 || hash == -1 {
                 // Unused slots are 0, Dummy slots are -1
                 continue;
             }
-            let value_addr: *mut I::Object = process.copy_struct(key_ptr + i * 2 * std::mem::size_of::<usize>())?;
+            let value_addr: *mut I::Object =
+                process.copy_struct(key_ptr + i * 2 * std::mem::size_of::<usize>())?;
             let value = format_variable::<I, P>(process, version, value_addr as usize, remaining)?;
             remaining -= value.len() as isize + 2;
             if remaining <= 5 {

--- a/src/python_interpreters.rs
+++ b/src/python_interpreters.rs
@@ -31,6 +31,21 @@ pub trait InterpreterState: Copy {
     fn modules_ptr_ptr(interpreter_address: usize) -> *const *const Self::Object;
 }
 
+pub trait HasGcGenerations: InterpreterState {
+    type Generation: 'static;
+    type GcHead: GcHead;
+
+    fn gc_generations(interpreter_address: usize) -> &'static [Self::Generation; 3];
+    fn generation_head_addr(gen: &Self::Generation) -> *const Self::GcHead;
+}
+
+pub trait GcHead: Copy {
+    type Object: Object;
+
+    fn next(&self) -> *mut Self;
+    fn obj_addr(&self, self_address: usize) -> usize;
+}
+
 pub trait ThreadState: Copy {
     type FrameObject: FrameObject;
     type InterpreterState: InterpreterState;
@@ -426,6 +441,84 @@ macro_rules! Python3Impl {
     };
 }
 
+// GcHead for 3.9~3.13 (before incremental GC)
+macro_rules! GcHeadNoMaskingImpl {
+    ($py: ident) => {
+        impl GcHead for $py::PyGC_Head {
+            type Object = $py::PyObject;
+            fn next(&self) -> *mut Self {
+                self._gc_next as *mut Self
+            }
+            fn obj_addr(&self, self_address: usize) -> usize {
+                self_address + std::mem::size_of::<Self>()
+            }
+        }
+    };
+}
+
+// GcHead for 3.14+ (after incremental GC)
+macro_rules! GcHeadMaskingImpl {
+    ($py: ident) => {
+        impl GcHead for $py::PyGC_Head {
+            type Object = $py::PyObject;
+            fn next(&self) -> *mut Self {
+                const MASK: usize = !0b11; // -1 << 2
+                (self._gc_next & MASK) as *mut Self
+            }
+            fn obj_addr(&self, self_address: usize) -> usize {
+                self_address + std::mem::size_of::<Self>()
+            }
+        }
+    };
+}
+
+// Python 3.9~3.13
+macro_rules! HasGcGenerationsFlatImpl {
+    ($py: ident) => {
+        impl HasGcGenerations for $py::PyInterpreterState {
+            type Generation = $py::gc_generation;
+            type GcHead = $py::PyGC_Head;
+
+            fn gc_generations(interpreter_address: usize) -> &'static [Self::Generation; 3] {
+                unsafe {
+                    &*((interpreter_address
+                        + std::mem::offset_of!(Self, gc)
+                        + std::mem::offset_of!($py::_gc_runtime_state, generations))
+                        as *const [Self::Generation; 3])
+                }
+            }
+
+            fn generation_head_addr(gen: &Self::Generation) -> *const Self::GcHead {
+                &gen.head
+            }
+        }
+    };
+}
+
+// Python 3.14+
+macro_rules! HasGcGenerationsYoungImpl {
+    ($py: ident) => {
+        impl HasGcGenerations for $py::PyInterpreterState {
+            type Generation = $py::gc_generation;
+            type GcHead = $py::PyGC_Head;
+
+            fn gc_generations(interpreter_address: usize) -> &'static [Self::Generation; 3] {
+                // This is a hack that assumes "young" is followed directly by "old" [;2]
+                unsafe {
+                    &*((interpreter_address
+                        + std::mem::offset_of!(Self, gc)
+                        + std::mem::offset_of!($py::_gc_runtime_state, young))
+                        as *const [Self::Generation; 3])
+                }
+            }
+
+            fn generation_head_addr(gen: &Self::Generation) -> *const Self::GcHead {
+                &gen.head
+            }
+        }
+    };
+}
+
 // Python 3.14
 Python3Impl!(v3_14_0);
 
@@ -510,6 +603,9 @@ impl TypeObject for v3_14_0::PyTypeObject {
 
 CompactCodeObjectImpl!(v3_14_0, PyBytesObject, PyUnicodeObject);
 
+HasGcGenerationsYoungImpl!(v3_14_0);
+GcHeadMaskingImpl!(v3_14_0);
+
 // Python 3.13
 Python3Impl!(v3_13_0);
 
@@ -593,6 +689,9 @@ impl TypeObject for v3_13_0::PyTypeObject {
 }
 
 CompactCodeObjectImpl!(v3_13_0, PyBytesObject, PyUnicodeObject);
+
+HasGcGenerationsFlatImpl!(v3_13_0);
+GcHeadNoMaskingImpl!(v3_13_0);
 
 // Python 3.12
 // TODO: this shares some similarities with python 3.11, we should refactor to a common macro
@@ -685,6 +784,9 @@ impl TypeObject for v3_12_0::PyTypeObject {
 
 CompactCodeObjectImpl!(v3_12_0, PyBytesObject, PyUnicodeObject);
 
+HasGcGenerationsFlatImpl!(v3_12_0);
+GcHeadNoMaskingImpl!(v3_12_0);
+
 // Python 3.11
 // Python3.11 is sufficiently different from previous versions that we can't use the macros above
 // to generate implementations of these traits.
@@ -773,6 +875,9 @@ impl TypeObject for v3_11_0::PyTypeObject {
 
 CompactCodeObjectImpl!(v3_11_0, PyBytesObject, PyUnicodeObject);
 
+HasGcGenerationsFlatImpl!(v3_11_0);
+GcHeadNoMaskingImpl!(v3_11_0);
+
 // Python 3.10
 Python3Impl!(v3_10_0);
 PythonCommonImpl!(v3_10_0, PyUnicodeObject);
@@ -836,10 +941,15 @@ impl CodeObject for v3_10_0::PyCodeObject {
     }
 }
 
+HasGcGenerationsFlatImpl!(v3_10_0);
+GcHeadNoMaskingImpl!(v3_10_0);
+
 // Python 3.9
 PythonCommonImpl!(v3_9_5, PyUnicodeObject);
 PythonCodeObjectImpl!(v3_9_5, PyBytesObject, PyUnicodeObject);
 Python3Impl!(v3_9_5);
+HasGcGenerationsFlatImpl!(v3_9_5);
+GcHeadNoMaskingImpl!(v3_9_5);
 
 // Python 3.8
 PythonCommonImpl!(v3_8_0, PyUnicodeObject);

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -11,12 +11,13 @@ use remoteprocess::{Pid, Process, ProcessMemory, Tid};
 use crate::config::{Config, LockingStrategy};
 #[cfg(feature = "unwind")]
 use crate::native_stack_trace::NativeStack;
+use crate::obj_walk::{get_object_attribute, walk_gc};
 use crate::python_bindings::{
     v2_7_15, v3_10_0, v3_11_0, v3_12_0, v3_13_0, v3_14_0, v3_3_7, v3_5_5, v3_6_6, v3_7_0, v3_8_0,
     v3_9_5,
 };
 use crate::python_data_access::format_variable;
-use crate::python_interpreters::{InterpreterState, ThreadState};
+use crate::python_interpreters::{HasGcGenerations, InterpreterState, ThreadState};
 use crate::python_process_info::{
     get_interpreter_address, get_python_version, get_threadstate_address, PythonProcessInfo,
 };
@@ -370,6 +371,83 @@ impl PythonSpy {
                         || frame.filename.contains("gevent")
                         || frame.filename.contains("tornado")))
         }
+    }
+
+    pub fn print_objects(&self) -> Result<(), Error> {
+        match self.version {
+            Version {
+                major: 3, minor: 9, ..
+            } => self._print_objects::<v3_9_5::_is>(),
+            Version {
+                major: 3,
+                minor: 10,
+                ..
+            } => self._print_objects::<v3_10_0::_is>(),
+            Version {
+                major: 3,
+                minor: 11,
+                ..
+            } => self._print_objects::<v3_11_0::_is>(),
+            Version {
+                major: 3,
+                minor: 12,
+                ..
+            } => self._print_objects::<v3_12_0::_is>(),
+            Version {
+                major: 3,
+                minor: 13,
+                ..
+            } => self._print_objects::<v3_13_0::_is>(),
+            Version {
+                major: 3,
+                minor: 14,
+                ..
+            } => self._print_objects::<v3_14_0::_is>(),
+            _ => Err(format_err!(
+                "Unsupported version of Python: {}",
+                self.version
+            )),
+        }
+    }
+
+    fn _print_objects<I>(&self) -> Result<(), Error>
+    where
+        I: HasGcGenerations,
+    {
+        let (type_name, attrs): (Option<&str>, Vec<&str>) = match self.config.object_path.as_deref()
+        {
+            Some(s) => {
+                let mut parts = s.split('.');
+                let first = parts.next();
+                let rest = parts.collect();
+                (first, rest)
+            }
+            None => (None, Vec::new()),
+        };
+
+        let objects = walk_gc::<I, Process>(self.interpreter_address, type_name, &self.process)?;
+        println!("Found {} object(s)", objects.len());
+
+        if !attrs.is_empty() {
+            for obj in objects {
+                println!("<{} at 0x{:x}>:", type_name.unwrap(), obj);
+                match get_object_attribute::<I, Process>(obj, &attrs, &self.process, &self.version)
+                {
+                    Ok(attr) => println!("{}", attr),
+                    Err(err) => println!("{}", err),
+                }
+            }
+        } else {
+            for obj in objects {
+                if let Ok(formatted) =
+                    format_variable::<I, Process>(&self.process, &self.version, obj, 200)
+                {
+                    println!("{}", formatted);
+                }
+            }
+        }
+
+        Ok(())
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
I found that this project has extensive capabilities for accessing object attributes and pretty-printing values of many different types, but it was only being used for printing locals in a stack frame and for some thread introspection. The potential for other uses is immense.

This PR adds a new command called `objects`, which allows introspection into live objects of an interpreter instance by walking the GC. It's supported for both, active processes and core dumps. All Python versions with active support are covered. Prior to 3.9, GC structures looked a bit different. 

Use cases:
* Debugging: What instances of a specific type are there and what values do specific attributes in them have?
* Forensics: Access runtime values in a Python process dump (possibly taken from a full system memory dump), e.g., to inspect malware.

A potential future extension could be to take an object address and print its entire attribute dict.
