### PR TITLE
Suggest enabling native unwinding when installing with cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ pip install py-spy
 You can also download prebuilt binaries from the [GitHub Releases
 Page](https://github.com/benfred/py-spy/releases).
 
-If you're a Rust user, py-spy can also be installed with: ```cargo install py-spy```. Note this
-builds py-spy from source and requires `libunwind` on Linux and Window, e.g., 
+If you're a Rust user, py-spy can also be installed with: ```cargo install py-spy -F unwind```. This
+builds py-spy from source and enables the feature for unwinding of native code, requiring `libunwind` on Linux and Window, e.g., 
 `apt install libunwind-dev`.
 
 On macOS, [py-spy is in Homebrew](https://formulae.brew.sh/formula/py-spy#default) and 


### PR DESCRIPTION
Small tweak to the README.

Otherwise, users would get "<tt>Collecting stack traces from native extensions (`--native`) is not supported on your platform.</tt>" their first time collecting samples with --native.