### PR TITLE
Add basic profiling support for CPython 3.14 free-threaded builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ mod native_stack_trace;
 mod python_bindings;
 mod python_data_access;
 mod python_interpreters;
+mod python_interpreters_3_14t;
 pub mod python_process_info;
 pub mod python_spy;
 mod python_threading;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod native_stack_trace;
 mod python_bindings;
 mod python_data_access;
 mod python_interpreters;
+mod python_interpreters_3_14t;
 mod python_process_info;
 mod python_spy;
 mod python_threading;

--- a/src/python_interpreters.rs
+++ b/src/python_interpreters.rs
@@ -112,6 +112,16 @@ pub trait TypeObject: Copy {
     fn flags(&self) -> usize;
 }
 
+pub(crate) fn stackref_as_object(bits: usize, tag_bits: usize) -> usize {
+    bits & !tag_bits
+}
+
+pub(crate) fn is_py314_entry_frame_owner(owner: ::std::os::raw::c_char) -> bool {
+    const FRAME_OWNED_BY_INTERPRETER: ::std::os::raw::c_char = 3;
+    const FRAME_OWNED_BY_CSTACK: ::std::os::raw::c_char = 4;
+    owner == FRAME_OWNED_BY_INTERPRETER || owner == FRAME_OWNED_BY_CSTACK
+}
+
 /// This macro provides a common impl for PyThreadState/PyFrameObject/PyCodeObject traits
 /// (this code is identical across python versions, we are only abstracting the struct layouts here).
 /// String handling changes substantially between python versions, and is handled separately.
@@ -473,19 +483,17 @@ impl ThreadState for v3_14_0::PyThreadState {
 impl FrameObject for v3_14_0::_PyInterpreterFrame {
     type CodeObject = v3_14_0::PyCodeObject;
     fn code(&self) -> *mut Self::CodeObject {
-        unsafe { self.f_executable.bits as *mut v3_14_0::PyCodeObject }
+        unsafe { stackref_as_object(self.f_executable.bits, 1) as *mut v3_14_0::PyCodeObject }
     }
     fn lasti(&self) -> i32 {
-        let co_code = unsafe { self.f_executable.bits as *const u8 };
+        let co_code = unsafe { stackref_as_object(self.f_executable.bits, 1) as *const u8 };
         unsafe { (self.instr_ptr as *const u8).offset_from(co_code) as i32 }
     }
     fn back(&self) -> *mut Self {
         self.previous
     }
     fn is_entry(&self) -> bool {
-        // https://github.com/python/cpython/pull/108036#issuecomment-1684458828
-        const FRAME_OWNED_BY_CSTACK: ::std::os::raw::c_char = 3;
-        self.owner == FRAME_OWNED_BY_CSTACK
+        is_py314_entry_frame_owner(self.owner)
     }
 }
 

--- a/src/python_interpreters_3_14t.rs
+++ b/src/python_interpreters_3_14t.rs
@@ -1,0 +1,382 @@
+/* Minimal CPython 3.14 free-threaded interpreter layout.
+
+This intentionally lives outside the generated v3_14_0 bindings.  CPython's
+free-threaded ABI changes the PyObject/PyVarObject header layout, so sharing the
+normal 3.14 PyUnicodeObject/PyBytesObject bindings corrupts string and line
+table reads.  The offsets below are the small subset needed for basic stack
+profiling and come from CPython 3.14t headers/debug offsets.
+*/
+
+use std::os::raw::{c_char, c_ulong};
+
+use crate::python_interpreters::{
+    is_py314_entry_frame_owner, stackref_as_object, BytesObject, CodeObject, FrameObject,
+    InterpreterState, ListObject, Object, StringObject, ThreadState, TupleObject, TypeObject,
+};
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyInterpreterState;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyThreadState {
+    pub prev: *mut PyThreadState,
+    pub next: *mut PyThreadState,
+    pub interp: *mut PyInterpreterState,
+    _pad0: [u8; 48],
+    pub current_frame: *mut PyInterpreterFrame,
+    _pad1: [u8; 72],
+    pub thread_id: u64,
+    pub native_thread_id: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyInterpreterFrame {
+    pub f_executable: PyStackRef,
+    pub previous: *mut PyInterpreterFrame,
+    _pad0: [u8; 40],
+    pub instr_ptr: *mut u8,
+    _pad1: [u8; 14],
+    pub owner: c_char,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyStackRef {
+    pub bits: usize,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyCodeObject {
+    _pad0: [u8; 68],
+    pub co_argcount: i32,
+    _pad1: [u8; 12],
+    pub co_firstlineno: i32,
+    _pad2: [u8; 24],
+    pub co_localsplusnames: *mut PyTupleObject,
+    _pad3: [u8; 8],
+    pub co_filename: *mut PyUnicodeObject,
+    pub co_name: *mut PyUnicodeObject,
+    pub co_qualname: *mut PyUnicodeObject,
+    pub co_linetable: *mut PyBytesObject,
+    _pad4: [u8; 72],
+    pub co_code_adaptive: [u8; 1],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyObject {
+    _pad0: [u8; 24],
+    pub ob_type: *mut PyTypeObject,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyTypeObject {
+    _pad0: [u8; 40],
+    pub tp_name: *const c_char,
+    _pad1: [u8; 136],
+    pub tp_flags: c_ulong,
+    _pad2: [u8; 112],
+    pub tp_dictoffset: isize,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyBytesObject {
+    _pad0: [u8; 32],
+    pub ob_size: isize,
+    _pad1: [u8; 8],
+    pub ob_sval: [c_char; 1],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyUnicodeObject {
+    _pad0: [u8; 32],
+    pub length: isize,
+    pub hash: isize,
+    pub interned: u8,
+    pub state: u8,
+    _pad1: [u8; 6],
+    pub ascii_data: [u8; 16],
+    pub data: *mut std::ffi::c_void,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyTupleObject {
+    _pad0: [u8; 32],
+    pub ob_size: isize,
+    _pad1: [u8; 8],
+    pub ob_item: [*mut PyObject; 1],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyListObject {
+    _pad0: [u8; 32],
+    pub ob_size: isize,
+    pub ob_item: *mut *mut PyObject,
+}
+
+impl InterpreterState for PyInterpreterState {
+    type ThreadState = PyThreadState;
+    type Object = PyObject;
+    type StringObject = PyUnicodeObject;
+    type ListObject = PyListObject;
+    type TupleObject = PyTupleObject;
+    const HAS_GIL_RUNTIME_STATE: bool = true;
+
+    fn threadstate_ptr_ptr(interpreter_address: usize) -> *const *const Self::ThreadState {
+        (interpreter_address + 7344) as *const *const Self::ThreadState
+    }
+
+    fn modules_ptr_ptr(interpreter_address: usize) -> *const *const Self::Object {
+        (interpreter_address + 7712) as *const *const Self::Object
+    }
+}
+
+impl ThreadState for PyThreadState {
+    type FrameObject = PyInterpreterFrame;
+    type InterpreterState = PyInterpreterState;
+
+    fn interp(&self) -> *mut Self::InterpreterState {
+        self.interp
+    }
+
+    fn frame_address(&self) -> Option<usize> {
+        None
+    }
+
+    fn frame(&self, _offset: Option<usize>) -> *mut Self::FrameObject {
+        self.current_frame
+    }
+
+    fn thread_id(&self) -> u64 {
+        self.thread_id
+    }
+
+    fn native_thread_id(&self) -> Option<u64> {
+        Some(self.native_thread_id)
+    }
+
+    fn next(&self) -> *mut Self {
+        self.next
+    }
+}
+
+impl FrameObject for PyInterpreterFrame {
+    type CodeObject = PyCodeObject;
+
+    fn code(&self) -> *mut Self::CodeObject {
+        stackref_as_object(self.f_executable.bits, 1) as *mut PyCodeObject
+    }
+
+    fn lasti(&self) -> i32 {
+        let code = stackref_as_object(self.f_executable.bits, 1) as *const u8;
+        unsafe { self.instr_ptr.cast_const().offset_from(code) as i32 }
+    }
+
+    fn back(&self) -> *mut Self {
+        self.previous
+    }
+
+    fn is_entry(&self) -> bool {
+        is_py314_entry_frame_owner(self.owner)
+    }
+}
+
+impl CodeObject for PyCodeObject {
+    type BytesObject = PyBytesObject;
+    type StringObject = PyUnicodeObject;
+    type TupleObject = PyTupleObject;
+
+    fn name(&self) -> *mut Self::StringObject {
+        self.co_name
+    }
+
+    fn filename(&self) -> *mut Self::StringObject {
+        self.co_filename
+    }
+
+    fn qualname(&self) -> Option<*mut Self::StringObject> {
+        Some(self.co_qualname)
+    }
+
+    fn line_table(&self) -> *mut Self::BytesObject {
+        self.co_linetable
+    }
+
+    fn first_lineno(&self) -> i32 {
+        self.co_firstlineno
+    }
+
+    fn nlocals(&self) -> i32 {
+        0
+    }
+
+    fn argcount(&self) -> i32 {
+        self.co_argcount
+    }
+
+    fn varnames(&self) -> *mut Self::TupleObject {
+        self.co_localsplusnames
+    }
+
+    fn get_line_number(&self, lasti: i32, table: &[u8]) -> i32 {
+        const CO_CODE_ADAPTIVE_OFFSET: i32 = 232;
+        let lasti = lasti - CO_CODE_ADAPTIVE_OFFSET;
+        let mut line_number = self.first_lineno();
+        let mut bytecode_address = 0;
+        let mut index = 0;
+
+        loop {
+            if index >= table.len() {
+                break;
+            }
+            let byte = table[index];
+            index += 1;
+
+            let delta = ((byte & 7) as i32) + 1;
+            bytecode_address += delta * 2;
+            let code = (byte >> 3) & 15;
+            let line_delta = match code {
+                15 => 0,
+                14 => {
+                    let delta = read_signed_varint(&mut index, table).unwrap_or(0);
+                    read_varint(&mut index, table);
+                    read_varint(&mut index, table);
+                    read_varint(&mut index, table);
+                    delta
+                }
+                13 => read_signed_varint(&mut index, table).unwrap_or(0),
+                10..=12 => {
+                    index += 2;
+                    (code - 10).into()
+                }
+                _ => {
+                    index += 1;
+                    0
+                }
+            };
+            line_number += line_delta as i32;
+            if bytecode_address >= lasti {
+                break;
+            }
+        }
+        line_number
+    }
+}
+
+impl Object for PyObject {
+    type TypeObject = PyTypeObject;
+
+    fn ob_type(&self) -> *mut Self::TypeObject {
+        self.ob_type
+    }
+}
+
+impl TypeObject for PyTypeObject {
+    fn name(&self) -> *const c_char {
+        self.tp_name
+    }
+
+    fn dictoffset(&self) -> isize {
+        self.tp_dictoffset
+    }
+
+    fn flags(&self) -> usize {
+        self.tp_flags as usize
+    }
+}
+
+impl BytesObject for PyBytesObject {
+    fn size(&self) -> usize {
+        self.ob_size as usize
+    }
+
+    fn address(&self, base: usize) -> usize {
+        base + 48
+    }
+}
+
+impl StringObject for PyUnicodeObject {
+    fn ascii(&self) -> bool {
+        (self.state >> 4) & 0x01 != 0
+    }
+
+    fn kind(&self) -> u32 {
+        (self.state & 0x07) as u32
+    }
+
+    fn size(&self) -> usize {
+        self.length as usize
+    }
+
+    fn address(&self, base: usize) -> usize {
+        const COMPACT_MASK: u8 = 0x08;
+        if self.state & COMPACT_MASK == 0 {
+            self.data as usize
+        } else if self.ascii() {
+            base + 56
+        } else {
+            base + 72
+        }
+    }
+}
+
+impl TupleObject for PyTupleObject {
+    fn size(&self) -> usize {
+        self.ob_size as usize
+    }
+
+    fn address(&self, base: usize, index: usize) -> usize {
+        base + 48 + index * std::mem::size_of::<*mut PyObject>()
+    }
+}
+
+impl ListObject for PyListObject {
+    type Object = PyObject;
+
+    fn size(&self) -> usize {
+        self.ob_size as usize
+    }
+
+    fn item(&self) -> *mut *mut Self::Object {
+        self.ob_item
+    }
+}
+
+fn read_varint(index: &mut usize, table: &[u8]) -> Option<usize> {
+    if *index >= table.len() {
+        return None;
+    }
+    let mut byte = table[*index];
+    let mut ret = (byte & 63) as usize;
+    let mut shift = 0;
+    *index += 1;
+
+    while byte & 64 != 0 {
+        if *index >= table.len() {
+            return None;
+        }
+        byte = table[*index];
+        *index += 1;
+        shift += 6;
+        ret += ((byte & 63) as usize) << shift;
+    }
+    Some(ret)
+}
+
+fn read_signed_varint(index: &mut usize, table: &[u8]) -> Option<isize> {
+    let unsigned_val = read_varint(index, table)?;
+    if unsigned_val & 1 != 0 {
+        Some(-((unsigned_val >> 1) as isize))
+    } else {
+        Some((unsigned_val >> 1) as isize)
+    }
+}

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -393,6 +393,31 @@ where
     ))
 }
 
+pub fn is_python_free_threaded<P>(
+    python_info: &PythonProcessInfo,
+    process: &P,
+    version: &Version,
+) -> bool
+where
+    P: ProcessMemory,
+{
+    match version {
+        Version {
+            major: 3,
+            minor: 14,
+            ..
+        } => python_info
+            .get_symbol("_PyRuntime")
+            .and_then(|&addr| {
+                process
+                    .copy_struct::<v3_14_0::_Py_DebugOffsets>(addr as usize)
+                    .ok()
+            })
+            .is_some_and(|debug_offsets| debug_offsets.free_threaded != 0),
+        _ => false,
+    }
+}
+
 pub fn get_interpreter_address<P>(
     python_info: &PythonProcessInfo,
     process: &P,
@@ -817,7 +842,7 @@ pub fn get_windows_python_symbols(
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub fn is_python_lib(pathname: &str) -> bool {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"/libpython\d.\d\d?(m|d|u)?.so").unwrap();
+        static ref RE: Regex = Regex::new(r"/libpython\d.\d\d?(m|d|t|u)?.so").unwrap();
     }
     RE.is_match(pathname)
 }
@@ -825,7 +850,7 @@ pub fn is_python_lib(pathname: &str) -> bool {
 #[cfg(target_os = "macos")]
 pub fn is_python_lib(pathname: &str) -> bool {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"/libpython\d.\d\d?(m|d|u)?.(dylib|so)$").unwrap();
+        static ref RE: Regex = Regex::new(r"/libpython\d.\d\d?(m|d|t|u)?.(dylib|so)$").unwrap();
     }
     RE.is_match(pathname) || is_python_framework(pathname)
 }
@@ -878,6 +903,7 @@ mod tests {
         assert!(is_python_lib("./libpython2.7.so"));
         assert!(is_python_lib("/usr/lib/libpython3.4d.so"));
         assert!(is_python_lib("/usr/local/lib/libpython3.8m.so"));
+        assert!(is_python_lib("/opt/python314t/lib/libpython3.14t.so.1.0"));
         assert!(is_python_lib("/usr/lib/libpython2.7u.so"));
 
         // don't blindly match libraries with python in the name (boost_python etc)

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -17,8 +17,10 @@ use crate::python_bindings::{
 };
 use crate::python_data_access::format_variable;
 use crate::python_interpreters::{InterpreterState, ThreadState};
+use crate::python_interpreters_3_14t as v3_14t;
 use crate::python_process_info::{
-    get_interpreter_address, get_python_version, get_threadstate_address, PythonProcessInfo,
+    get_interpreter_address, get_python_version, get_threadstate_address, is_python_free_threaded,
+    PythonProcessInfo,
 };
 use crate::python_threading::thread_name_lookup;
 use crate::stack_trace::{get_gil_threadid, get_stack_trace, StackTrace};
@@ -29,6 +31,7 @@ pub struct PythonSpy {
     pub pid: Pid,
     pub process: Process,
     pub version: Version,
+    pub free_threaded: bool,
     pub interpreter_address: usize,
     pub threadstate_address: usize,
     pub config: Config,
@@ -58,6 +61,15 @@ impl PythonSpy {
 
         let version = get_python_version(&python_info, &process)?;
         info!("python version {} detected", version);
+        let free_threaded = is_python_free_threaded(&python_info, &process, &version);
+        if free_threaded {
+            info!("free-threaded python build detected");
+            if config.gil_only {
+                return Err(format_err!(
+                    "--gil is not supported for free-threaded Python builds"
+                ));
+            }
+        }
 
         let interpreter_address = get_interpreter_address(&python_info, &process, &version)?;
         info!("Found interpreter at 0x{:016x}", interpreter_address);
@@ -86,6 +98,7 @@ impl PythonSpy {
             pid,
             process,
             version,
+            free_threaded,
             interpreter_address,
             threadstate_address,
             #[cfg(feature = "unwind")]
@@ -181,6 +194,11 @@ impl PythonSpy {
                 major: 3,
                 minor: 14,
                 ..
+            } if self.free_threaded => self._get_stack_traces::<v3_14t::PyInterpreterState>(),
+            Version {
+                major: 3,
+                minor: 14,
+                ..
             } => self._get_stack_traces::<v3_14_0::_is>(),
             _ => Err(format_err!(
                 "Unsupported version of Python: {}",
@@ -226,8 +244,19 @@ impl PythonSpy {
             .context("Failed to copy PyThreadState head pointer")?;
 
         // get the threadid of the gil if appropriate
-        let gil_thread_id = get_gil_threadid::<I, Process>(self.threadstate_address, &self.process)
-            .context("failed to get gil_thread_id")?;
+        let gil_thread_id =
+            match get_gil_threadid::<I, Process>(self.threadstate_address, &self.process) {
+                Ok(thread_id) => thread_id,
+                Err(err) if self.config.gil_only => {
+                    return Err(err).context("failed to get gil_thread_id")
+                }
+                Err(err) => {
+                    warn!(
+                        "failed to get gil_thread_id, continuing without GIL ownership data: {err}"
+                    );
+                    0
+                }
+            };
 
         let mut traces = Vec::new();
         let mut threads = threads_head;

--- a/src/python_threading.rs
+++ b/src/python_threading.rs
@@ -93,6 +93,10 @@ fn _thread_name_lookup<I: InterpreterState>(
 // processing we only handle py3.6+ right now, and this doesn't work at all if the
 // threading module isn't imported in the target program
 pub fn thread_name_lookup(process: &PythonSpy) -> Option<HashMap<u64, String>> {
+    if process.free_threaded {
+        return None;
+    }
+
     let err = match process.version {
         Version {
             major: 3, minor: 6, ..

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -79,7 +79,14 @@ where
     I: InterpreterState,
     P: ProcessMemory,
 {
-    let gil_thread_id = get_gil_threadid::<I, P>(threadstate_address, process)?;
+    let gil_thread_id = match get_gil_threadid::<I, P>(threadstate_address, process) {
+        Ok(thread_id) => thread_id,
+        Err(err) if config.is_some_and(|c| c.gil_only) => return Err(err),
+        Err(err) => {
+            warn!("failed to get gil_thread_id, continuing without GIL ownership data: {err}");
+            0
+        }
+    };
 
     let threadstate_ptr_ptr = I::threadstate_ptr_ptr(interpreter_address);
     let mut threads: *const I::ThreadState = process


### PR DESCRIPTION
## Summary

This PR adds basic stack sampling support for CPython 3.14 free-threaded builds.

It is intentionally scoped as the first step for #711:

- recognize `libpython3.14t` shared libraries
- detect CPython 3.14 free-threaded builds through `_PyRuntime.debug_offsets.free_threaded`
- add a minimal CPython 3.14t interpreter layout for stack walking, code object names, filenames, and line numbers
- route CPython 3.14t stack sampling through that layout
- skip thread-name lookup for free-threaded builds for now
- return a clear unsupported error for `--gil` on free-threaded Python builds

Out of scope for this PR:

- CPython 3.13t support
- locals
- thread names
- native stack unwinding
- memory profiling
- core dump support
- subinterpreter coverage

Related to #711.

## Validation

- `cargo fmt --check`
- `CARGO_HOME=/home/honglei/bwh/.cargo-py-spy cargo test --lib`
  - 14 passed
- `CARGO_HOME=/home/honglei/bwh/.cargo-py-spy cargo test --release`
  - lib tests: 14 passed
  - main tests: 15 passed
  - integration tests: 12 passed
  - doc tests: 1 passed
- Remote Linux x86_64, CPython 3.14t (`/opt/python314t/bin/python3`):
  - `cargo +stable build --release`
  - `cargo +stable test --lib`
  - `py-spy record -f raw -d 60 -- /opt/python314t/bin/python3 busy_314t.py`
  - result: `Samples: 5999 Errors: 0`
  - raw output contains `busy_loop`
  - `py-spy dump -p <pid>` contains `busy_loop`
  - `py-spy record --gil ...` fails with `--gil is not supported for free-threaded Python builds`
- Remote Linux x86_64 ordinary-GIL regression checks:
  - CPython 3.14: 60s `record -f raw`, `Samples: 5999 Errors: 0`
  - CPython 3.13: 60s `record -f raw`, `Samples: 5999 Errors: 0`
  - CPython 3.12: 60s `record -f raw`, `Samples: 5999 Errors: 0`

## AI assistance disclosure

This PR was prepared with assistance from Codex / GPT-5.5. The implementation and the validation results above were checked with local and remote test runs before submission.
