### PR TITLE
Skip thread-name lookup for outputs that do not use names

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,8 @@ pub struct Config {
     #[doc(hidden)]
     pub include_thread_ids: bool,
     #[doc(hidden)]
+    pub collect_thread_names: bool,
+    #[doc(hidden)]
     pub subprocesses: bool,
     #[doc(hidden)]
     pub gil_only: bool,
@@ -126,6 +128,7 @@ impl Default for Config {
             gil_only: false,
             include_idle: false,
             include_thread_ids: false,
+            collect_thread_names: true,
             hide_progress: false,
             capture_output: true,
             dump_json: false,
@@ -447,6 +450,11 @@ impl Config {
 
         config.subprocesses = matches.get_flag("subprocesses");
         config.command = subcommand.to_owned();
+        config.collect_thread_names = match subcommand {
+            "record" => config.include_thread_ids || config.format == Some(FileFormat::speedscope),
+            "top" => false,
+            _ => true,
+        };
 
         // options that can be shared between subcommands
         config.pid = matches.get_one::<String>("pid").map(|p| {
@@ -558,11 +566,26 @@ mod tests {
         assert_eq!(config.include_idle, false);
         assert_eq!(config.gil_only, false);
         assert_eq!(config.include_thread_ids, false);
+        assert_eq!(config.collect_thread_names, false);
 
         let config_flags = get_config("py-spy r -p 1234 -o foo --idle --gil --threads").unwrap();
         assert_eq!(config_flags.include_idle, true);
         assert_eq!(config_flags.gil_only, true);
         assert_eq!(config_flags.include_thread_ids, true);
+        assert_eq!(config_flags.collect_thread_names, true);
+
+        let speedscope = get_config("py-spy record -p 1234 -f speedscope").unwrap();
+        assert_eq!(speedscope.collect_thread_names, true);
+
+        let raw = get_config("py-spy record -p 1234 -f raw").unwrap();
+        assert_eq!(raw.collect_thread_names, false);
+
+        let chrometrace = get_config("py-spy record -p 1234 -f chrometrace").unwrap();
+        assert_eq!(chrometrace.collect_thread_names, false);
+
+        let chrometrace_threads =
+            get_config("py-spy record -p 1234 -f chrometrace --threads").unwrap();
+        assert_eq!(chrometrace_threads.collect_thread_names, true);
     }
 
     #[test]
@@ -571,6 +594,7 @@ mod tests {
         let config = get_config("py-spy dump --pid 1234").unwrap();
         assert_eq!(config.pid, Some(1234));
         assert_eq!(config.command, String::from("dump"));
+        assert_eq!(config.collect_thread_names, true);
 
         // short version
         let short_config = get_config("py-spy d -p 1234").unwrap();
@@ -589,6 +613,7 @@ mod tests {
         let config = get_config("py-spy top --pid 1234").unwrap();
         assert_eq!(config.pid, Some(1234));
         assert_eq!(config.command, String::from("top"));
+        assert_eq!(config.collect_thread_names, false);
 
         // short version
         let short_config = get_config("py-spy t -p 1234").unwrap();

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -283,7 +283,11 @@ impl PythonSpy {
                 trace.os_thread_id = os_thread_id.map(|id| id as u64);
             }
 
-            trace.thread_name = self._get_python_thread_name(python_thread_id);
+            trace.thread_name = if self.config.collect_thread_names {
+                self._get_python_thread_name(python_thread_id)
+            } else {
+                None
+            };
             trace.owns_gil = owns_gil;
             trace.pid = self.process.pid;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -167,6 +167,27 @@ fn test_thread_names() {
 }
 
 #[test]
+fn test_skip_thread_names() {
+    #[cfg(target_os = "macos")]
+    {
+        // We need root permissions here to run this on OSX
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+    }
+    let config = Config {
+        collect_thread_names: false,
+        include_idle: true,
+        ..Default::default()
+    };
+    let mut runner = TestRunner::new(config, "./tests/scripts/thread_names.py");
+
+    let traces = runner.spy.get_stack_traces().unwrap();
+    assert_eq!(traces.len(), 11);
+    assert!(traces.iter().all(|trace| trace.thread_name.is_none()));
+}
+
+#[test]
 fn test_recursive() {
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
Full disclosure: This has been written by GPT 5.6 Sol.
It is a symptom-treat for https://github.com/benfred/py-spy/pull/855#issuecomment-5001837096 that I consider generally useful.

## Summary

- skip remote thread-name collection when the selected CLI output does not consume names
- keep collection enabled for `dump`, speedscope, and every recording using `--threads`
- preserve the current default for library users, who can also opt out explicitly through `Config`

## Motivation

Thread names are resolved by walking the target process's `sys.modules` and the `threading` module's `_active` dictionary. This work does not contribute to several outputs:

- `top` does not display individual thread names
- flamegraph and raw recordings use names only when `--threads` adds a synthetic thread frame
- chrometrace likewise uses names only with `--threads`

Avoiding the lookup matters especially when it fails: the name cache remains empty and py-spy retries the remote dictionary walk for every sampled thread on every sample. This change makes the collection decision before `PythonSpy::retry_new`, so even the validation sample avoids unused lookup work.

Speedscope continues collecting names because it uses them as profile labels. `dump` and direct `PythonSpy` users retain the existing behavior by default.

This PR is independent of #861 and applies directly to `master`.

## Validation

- regression test confirming disabled collection leaves all sampled thread names unset
- output-policy tests for top, dump, flamegraph, raw, speedscope, and chrometrace with/without `--threads`
- `pre-commit run --all-files`
- `cargo test --release` with Python 3.13
- `cargo test --lib`
- `cargo check --all-targets`
- `cargo check --lib --no-default-features`
