### PR TITLE
fix: properly find interpreter base when libffi static trampolines remap a page of the binary

### DIFF
--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -72,21 +72,32 @@ impl PythonProcessInfo {
         // parse the main python binary
         let (python_binary, python_filename) = {
             // Get the memory address for the executable by matching against virtual memory maps
-            let map = maps.iter().find(|m| {
-                if let Some(pathname) = m.filename() {
-                    if let Some(pathname) = pathname.to_str() {
-                        #[cfg(not(windows))]
-                        {
-                            return is_python_bin(pathname) && m.is_exec();
-                        }
-                        #[cfg(windows)]
-                        {
-                            return is_python_bin(pathname);
+            let binary_maps: Vec<_> = maps
+                .iter()
+                .filter(|m| {
+                    if let Some(pathname) = m.filename() {
+                        if let Some(pathname) = pathname.to_str() {
+                            #[cfg(not(windows))]
+                            {
+                                return is_python_bin(pathname) && m.is_exec();
+                            }
+                            #[cfg(windows)]
+                            {
+                                return is_python_bin(pathname);
+                            }
                         }
                     }
-                }
-                false
-            });
+                    false
+                })
+                .collect();
+
+            // Statically linked libffi >= 3.4 re-mmaps a page of the executable at an
+            // arbitrary address for its static trampolines; take the mapping with the
+            // lowest file offset to get the real text segment (like libpython below).
+            #[cfg(target_os = "linux")]
+            let map = binary_maps.iter().min_by_key(|m| m.offset).copied();
+            #[cfg(not(target_os = "linux"))]
+            let map = binary_maps.first().copied();
 
             let map = match map {
                 Some(map) => map,


### PR DESCRIPTION
Fixes #865

Statically linked libffi >= 3.4 (e.g. python-build-standalone builds, as installed by uv) re-mmaps a one-page executable slice of the python binary for its static trampoline table when the process creates its first ctypes/cffi closure (`import numba` is enough). That page sorts first in the process maps, so `PythonProcessInfo::new` computed the interpreter base from it and attach failed (`Bad address (os error 14)` / `Failed to copy Py_Version symbol` / `Failed to find a python version`). Details and repro in #865.

Fix: collect all executable maps matching the binary and take the one with the lowest file offset (the real text segment; the trampoline page has a large non-zero offset), mirroring the existing libpython map selection a few lines below.

Verified on Linux x86_64 with uv-managed CPython 3.11.14: attach to a process with a ctypes callback (and one with `import numba`) now works, clean processes unaffected. Unit tests pass; the integration suite fails a varying subset of line-number/local-var assertions on my machine both with and without this change (python-version-related, not touched by this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)