### PR TITLE
Add Windows ARM64 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,23 +31,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - name: Install Dependencies
         run: sudo apt install libunwind-dev
         if: runner.os == 'Linux'
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
       - name: Build
         run: cargo build --release --verbose --examples
       - name: Build library
         run: cargo build --release --verbose --lib --no-default-features
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install optional numpy dependency
         run: pip install numpy>=2
       - name: Test
@@ -86,7 +83,7 @@ jobs:
       - name: Upload Windows Wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-windows
+          name: wheels-${{ matrix.os }}
           path: dist
         if: runner.os == 'Windows'
       - name: Upload Macos Wheels
@@ -225,11 +222,20 @@ jobs:
             3.14.3,
             3.14.4,
           ]
-        os: [ubuntu-22.04, macos-latest, windows-latest, ubuntu-22.04-arm]
+        os:
+          [
+            ubuntu-22.04,
+            macos-latest,
+            windows-latest,
+            windows-11-arm,
+            ubuntu-22.04-arm,
+          ]
         # some versions of python can't be tested on GHA with osx because of SIP:
         exclude:
           - os: macos-latest
             python-version: 3.6.7
+          - os: windows-11-arm
+            python-version: 3.6.7
           - os: ubuntu-22.04
             python-version: 3.6.7
           - os: ubuntu-22.04-arm
@@ -238,11 +244,15 @@ jobs:
             python-version: 3.6.15
           - os: windows-latest
             python-version: 3.6.15
+          - os: windows-11-arm
+            python-version: 3.6.15
           - os: ubuntu-22.04
             python-version: 3.6.15
           - os: ubuntu-22.04-arm
             python-version: 3.6.15
           - os: macos-latest
+            python-version: 3.7.1
+          - os: windows-11-arm
             python-version: 3.7.1
           - os: ubuntu-22.04
             python-version: 3.7.1
@@ -252,9 +262,13 @@ jobs:
             python-version: 3.7.17
           - os: windows-latest
             python-version: 3.7.17
+          - os: windows-11-arm
+            python-version: 3.7.17
           - os: ubuntu-22.04-arm
             python-version: 3.7.17
           - os: macos-latest
+            python-version: 3.8.0
+          - os: windows-11-arm
             python-version: 3.8.0
           - os: ubuntu-22.04
             python-version: 3.8.0
@@ -264,7 +278,11 @@ jobs:
             python-version: 3.8.18
           - os: windows-latest
             python-version: 3.8.18
+          - os: windows-11-arm
+            python-version: 3.8.18
           - os: macos-latest
+            python-version: 3.9.0
+          - os: windows-11-arm
             python-version: 3.9.0
           - os: ubuntu-22.04
             python-version: 3.9.0
@@ -274,7 +292,11 @@ jobs:
             python-version: 3.9.25
           - os: windows-latest
             python-version: 3.9.25
+          - os: windows-11-arm
+            python-version: 3.9.25
           - os: macos-latest
+            python-version: 3.10.0
+          - os: windows-11-arm
             python-version: 3.10.0
           - os: ubuntu-22.04
             python-version: 3.10.0
@@ -283,14 +305,20 @@ jobs:
           - os: macos-latest
             python-version: 3.10.20
           - os: windows-latest
+            python-version: 3.10.20
+          - os: windows-11-arm
             python-version: 3.10.20
           - os: macos-latest
             python-version: 3.11.15
           - os: windows-latest
+            python-version: 3.11.15
+          - os: windows-11-arm
             python-version: 3.11.15
           - os: macos-latest
             python-version: 3.12.13
           - os: windows-latest
+            python-version: 3.12.13
+          - os: windows-11-arm
             python-version: 3.12.13
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,6 +328,18 @@ jobs:
         with:
           pattern: wheels-*
           merge-multiple: true
+      # The windows-11-arm runner includes a few versions of Python, and the
+      # installer downloaded by actions/setup-python does not cleanly remove
+      # all registry entries, so the leftover newer install blocks any older
+      # patch release. See actions/setup-python#1267.
+      - name: Remove Python registry entries
+        run: |
+          . ./ci/remove_python_registry_entries.ps1
+          Remove-RegistryEntries -Architecture arm64 -MajorVersion 3 -MinorVersion 12
+          Remove-RegistryEntries -Architecture arm64 -MajorVersion 3 -MinorVersion 13
+          Remove-RegistryEntries -Architecture arm64 -MajorVersion 3 -MinorVersion 14
+        if: matrix.os == 'windows-11-arm'
+        continue-on-error: true
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,8 @@ jobs:
         run: cargo build --release --verbose --lib --no-default-features
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          # Windows on arm64 has no CPython builds before 3.11
+          python-version: ${{ matrix.os == 'windows-11-arm' && '3.11' || '3.9' }}
       - name: Install optional numpy dependency
         run: pip install numpy>=2
       - name: Test

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,11 @@ fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     match (target_arch.as_ref(), target_os.as_ref()) {
-        ("x86_64", "windows") | ("x86_64", "linux") | ("arm", "linux") | ("aarch64", "linux") => {
+        ("x86_64", "windows")
+        | ("aarch64", "windows")
+        | ("x86_64", "linux")
+        | ("arm", "linux")
+        | ("aarch64", "linux") => {
             println!("cargo:rustc-cfg=unwind")
         }
         _ => {}

--- a/ci/remove_python_registry_entries.ps1
+++ b/ci/remove_python_registry_entries.ps1
@@ -1,0 +1,59 @@
+# From https://github.com/actions/python-versions/blob/main/installers/win-setup-template.ps1
+# The older Python releases we want to install on Windows ARM64 runners have a buggy version of
+# this script, so we call it ourselves to clean up newer versions.
+
+function Get-RegistryVersionFilter {
+    param(
+        [Parameter(Mandatory)][String] $Architecture,
+        [Parameter(Mandatory)][Int32] $MajorVersion,
+        [Parameter(Mandatory)][Int32] $MinorVersion
+    )
+
+    # ARM64 Python installer registers as "(ARM64)" in the display name, not "(64-bit)"
+    $archFilter = switch ($Architecture) {
+        'x86'   { "32-bit" }
+        'arm64' { "64-bit|ARM64" }
+        default { "64-bit" }
+    }
+    "Python $MajorVersion.$MinorVersion.*($archFilter)"
+}
+
+function Remove-RegistryEntries {
+    param(
+        [Parameter(Mandatory)][String] $Architecture,
+        [Parameter(Mandatory)][Int32] $MajorVersion,
+        [Parameter(Mandatory)][Int32] $MinorVersion
+    )
+
+    $versionFilter = Get-RegistryVersionFilter -Architecture $Architecture -MajorVersion $MajorVersion -MinorVersion $MinorVersion
+
+    $regPath = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products"
+    if (Test-Path -Path Registry::$regPath) {
+        $regKeys = Get-ChildItem -Path Registry::$regPath -Recurse | Where-Object Property -Ccontains DisplayName
+        foreach ($key in $regKeys) {
+            if ($key.getValue("DisplayName") -match $versionFilter) {
+                Remove-Item -Path $key.PSParentPath -Recurse -Force -Verbose
+            }
+        }
+    }
+
+    $regPath = "HKEY_CLASSES_ROOT\Installer\Products"
+    if (Test-Path -Path Registry::$regPath) {
+        Get-ChildItem -Path Registry::$regPath | Where-Object { $_.GetValue("ProductName") -match $versionFilter } | ForEach-Object {
+            Remove-Item Registry::$_ -Recurse -Force -Verbose
+        }
+    }
+
+    $uninstallRegistrySections = @(
+        "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall",  # current user, x64
+        "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall", # all users, x64
+        "HKEY_CURRENT_USER\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",  # current user, x86
+        "HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"  # all users, x86
+    )
+
+    $uninstallRegistrySections | Where-Object { Test-Path -Path Registry::$_ } | ForEach-Object {
+        Get-ChildItem -Path Registry::$_ | Where-Object { $_.getValue("DisplayName") -match $versionFilter } | ForEach-Object {
+            Remove-Item Registry::$_ -Recurse -Force -Verbose
+        }
+    }
+}

--- a/ci/update_python_test_versions.py
+++ b/ci/update_python_test_versions.py
@@ -111,6 +111,10 @@ def update_python_test_versions(force=False):
             exclusions.append("          - os: windows-latest\n")
             exclusions.append(f"            python-version: {v}\n")
 
+        if ("win32", "arm64") not in platforms[v]:
+            exclusions.append("          - os: windows-11-arm\n")
+            exclusions.append(f"            python-version: {v}\n")
+
         if ("linux", "x64") not in platforms[v]:
             exclusions.append("          - os: ubuntu-22.04\n")
             exclusions.append(f"            python-version: {v}\n")

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -520,7 +520,13 @@ fn test_negative_linenumber_increment() {
     // Python 3.12 inlined comprehensions - see https://peps.python.org/pep-0709/
     match (runner.spy.version.major, runner.spy.version.minor) {
         (3, 0..=11) => {
-            assert_eq!(trace.frames[0].name, "<listcomp>");
+            // 3.11 added co_qualname, which py-spy reports in preference to co_name
+            let listcomp = if runner.spy.version.minor >= 11 {
+                "f.<locals>.<listcomp>"
+            } else {
+                "<listcomp>"
+            };
+            assert_eq!(trace.frames[0].name, listcomp);
             assert!(trace.frames[0].line >= 5 && trace.frames[0].line <= 10);
             assert_eq!(trace.frames[1].name, "f");
             assert!(trace.frames[1].line >= 5 && trace.frames[0].line <= 10);


### PR DESCRIPTION
As the title says.

A few things to note:
- There were two identical setup-python steps in the build job. I have removed one, let me know if there was an actual purpose to it.
- The setup-python steps are specifically installing 3.9. The first official release for Windows ARM64 was in 3.11, so I have made that conditional to get 3.11 on WoA and 3.9 as before for everything else.
- There was a bug in older WoA releases of Python used by setup-python, which did not cleanly uninstall any already-installed newer versions. So I added that clean up script to the `ci` directory and call it in the workflow to do the cleanup ourselves, so we can install specific older versions as needed for tests.
- There was a bug in one of the Rust integration tests that was failing on 3.11 only, So I made a minor fix there.

Hopefully all of this looks okay, let me know if you would like me to change or remove anything.