### PR TITLE
feat: dump asyncio tasks and creation traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 py-spy: Sampling profiler for Python programs
 =====
-[![Build Status](https://github.com/benfred/py-spy/workflows/Build/badge.svg?branch=master)](https://github.com/benfred/py-spy/actions?query=branch%3Amaster)
-[![FreeBSD Build Status](https://api.cirrus-ci.com/github/benfred/py-spy.svg)](https://cirrus-ci.com/github/benfred/py-spy)
+[![Build Status](https://github.com/wuurrd/py-spy/workflows/Build/badge.svg?branch=master)](https://github.com/wuurrd/py-spy/actions?query=branch%3Amaster)
+
+> This fork adds read-only inspection of live asyncio tasks, including their
+> suspended frames and creation tracebacks. The upstream project is
+> [benfred/py-spy](https://github.com/benfred/py-spy).
 
 py-spy is a sampling profiler for Python programs. It lets you visualize what your Python
 program is spending time on without restarting the program or modifying the code in any way.
@@ -12,6 +15,18 @@ py-spy works on Linux, OSX, Windows and FreeBSD, and supports profiling all rece
 interpreter (versions 2.3-2.7 and 3.3-3.14).
 
 ## Installation
+
+To build this fork with asyncio task inspection:
+
+```bash
+git clone https://github.com/wuurrd/py-spy.git
+cd py-spy
+cargo build --release
+./target/release/py-spy dump --asyncio --pid 12345
+```
+
+The packages and binaries below are maintained by the upstream project and do
+not include this fork's asyncio additions.
 
 Prebuilt binary wheels can be installed from PyPI with:
 
@@ -94,6 +109,25 @@ console:
 This is useful for the case where you just need a single call stack to figure out where your
 python program is hung on. This command also has the ability to print out the local variables
 associated with each stack frame by setting the ```--locals``` flag.
+
+#### Asyncio tasks
+
+This fork can also inspect every live asyncio task without running code in the
+target process:
+
+```bash
+py-spy dump --asyncio --pid 12345
+```
+
+The additional `Asyncio Tasks` section includes each task's id, name, state,
+the frame where its coroutine is currently running or suspended, and its
+creation traceback when available. CPython only records creation tracebacks
+for tasks created while asyncio debug mode is enabled (for example with
+`PYTHONASYNCIODEBUG=1`, `asyncio.run(..., debug=True)`, or
+`loop.set_debug(True)`). It works with CPython 3.7 through 3.14 and can be
+combined with `--locals`. With `--asyncio --json`, the output is an object
+containing `threads` and `asyncio_tasks`; JSON output without `--asyncio`
+retains py-spy's original array format.
 
 ## Frequently Asked Questions
 

--- a/src/asyncio.rs
+++ b/src/asyncio.rs
@@ -1,0 +1,742 @@
+//! Read-only asyncio task inspection for a remote CPython process.
+//!
+//! This deliberately does not inject code or call `asyncio.all_tasks()` in the
+//! target. Instead it reads asyncio's task registries and the suspended
+//! coroutine frames directly from process memory.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Error, Result};
+use remoteprocess::ProcessMemory;
+use serde_derive::Serialize;
+
+use crate::config::LineNo;
+use crate::python_bindings::v3_14_0;
+use crate::python_data_access::{
+    copy_long, copy_string, copy_type_name, format_variable, DictIterator, SetIterator,
+    PY_TPFLAGS_MANAGED_DICT,
+};
+use crate::python_interpreters::{InterpreterState, ListObject, Object, ThreadState, TypeObject};
+use crate::stack_trace::{get_stack_frames, Frame};
+use crate::version::Version;
+
+const MAX_TASKS: usize = 100_000;
+const MAX_CREATION_FRAMES: usize = 10_000;
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct AsyncioDebugOffsets {
+    pub task: AsyncioTaskDebugOffsets,
+    pub interpreter: AsyncioInterpreterDebugOffsets,
+    pub thread: AsyncioThreadDebugOffsets,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct AsyncioTaskDebugOffsets {
+    pub size: u64,
+    pub name: u64,
+    pub awaited_by: u64,
+    pub is_task: u64,
+    pub awaited_by_is_set: u64,
+    pub coro: u64,
+    pub node: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct AsyncioInterpreterDebugOffsets {
+    pub size: u64,
+    pub tasks_head: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct AsyncioThreadDebugOffsets {
+    pub size: u64,
+    pub running_loop: u64,
+    pub running_task: u64,
+    pub tasks_head: u64,
+}
+
+impl AsyncioDebugOffsets {
+    pub(crate) fn is_sane(&self) -> bool {
+        self.task.size >= 128
+            && self.task.size < 4096
+            && self.task.name < self.task.size
+            && self.task.coro < self.task.size
+            && self.task.node < self.task.size
+            && self.interpreter.tasks_head < self.interpreter.size
+            && self.thread.running_task < self.thread.size
+            && self.thread.tasks_head < self.thread.size
+    }
+}
+
+/// A live asyncio task and the Python frame at which its coroutine is suspended.
+#[derive(Debug, Clone, Serialize)]
+pub struct AsyncioTask {
+    /// Address of the Task object in the target process, formatted as hex.
+    pub task_id: String,
+    /// Task name, when supported by the target Python version.
+    pub name: Option<String>,
+    /// `running`, `pending`, `cancelled`, or `finished`.
+    pub state: String,
+    /// The coroutine's current frame, represented like thread-dump frames.
+    pub frames: Vec<Frame>,
+    /// The stack that created this task, when asyncio debug mode captured it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creation_traceback: Option<Vec<Frame>>,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct TaskOffsets {
+    state: usize,
+    coro: usize,
+    name: Option<usize>,
+    source_traceback: usize,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct FrameSummaryOffsets {
+    filename: usize,
+    lineno: usize,
+    name: usize,
+}
+
+#[derive(Copy, Clone)]
+struct InspectionOffsets<'a> {
+    python: Option<&'a v3_14_0::_Py_DebugOffsets>,
+    asyncio: Option<&'a AsyncioDebugOffsets>,
+}
+
+fn task_offsets(version: &Version) -> Option<TaskOffsets> {
+    match (version.major, version.minor) {
+        (3, 7) => Some(TaskOffsets {
+            state: 72,
+            coro: 112,
+            name: None,
+            source_traceback: 64,
+        }),
+        (3, 8) => Some(TaskOffsets {
+            state: 72,
+            coro: 112,
+            name: Some(120),
+            source_traceback: 64,
+        }),
+        (3, 9) => Some(TaskOffsets {
+            state: 80,
+            coro: 152,
+            name: Some(160),
+            source_traceback: 64,
+        }),
+        (3, 10) => Some(TaskOffsets {
+            state: 88,
+            coro: 160,
+            name: Some(168),
+            source_traceback: 72,
+        }),
+        (3, 11 | 12) => Some(TaskOffsets {
+            state: 88,
+            coro: 136,
+            name: Some(144),
+            source_traceback: 72,
+        }),
+        (3, 13) => Some(TaskOffsets {
+            state: 96,
+            coro: 120,
+            name: Some(128),
+            source_traceback: 72,
+        }),
+        (3, 14) => Some(TaskOffsets {
+            state: 104,
+            coro: 128,
+            name: Some(136),
+            source_traceback: 72,
+        }),
+        _ => None,
+    }
+}
+
+fn frame_summary_offsets(version: &Version) -> Option<FrameSummaryOffsets> {
+    // FrameSummary uses __slots__. CPython lays these slots out in sorted name
+    // order immediately after PyObject_HEAD; the slot set changed in 3.11,
+    // 3.13, and 3.14.
+    match (version.major, version.minor) {
+        (3, 7..=10) => Some(FrameSummaryOffsets {
+            filename: 24,
+            lineno: 32,
+            name: 48,
+        }),
+        (3, 11 | 12) => Some(FrameSummaryOffsets {
+            filename: 48,
+            lineno: 56,
+            name: 72,
+        }),
+        (3, 13) => Some(FrameSummaryOffsets {
+            filename: 56,
+            lineno: 64,
+            name: 80,
+        }),
+        (3, 14) => Some(FrameSummaryOffsets {
+            filename: 64,
+            lineno: 72,
+            name: 88,
+        }),
+        _ => None,
+    }
+}
+
+fn coroutine_frame_offset(version: &Version) -> Option<usize> {
+    match (version.major, version.minor) {
+        (3, 7..=10) => Some(16),
+        (3, 11) => Some(88),
+        (3, 12..=14) => Some(72),
+        _ => None,
+    }
+}
+
+fn module_dict<I, P>(
+    interpreter_address: usize,
+    process: &P,
+    version: &Version,
+    wanted: &str,
+    debug_offsets: Option<&v3_14_0::_Py_DebugOffsets>,
+) -> Result<Option<usize>, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let modules_ptr_ptr = debug_offsets
+        .map(|offsets| {
+            (interpreter_address + offsets.interpreter_state.imports_modules as usize)
+                as *const *const I::Object
+        })
+        .unwrap_or_else(|| I::modules_ptr_ptr(interpreter_address));
+    let modules: *const I::Object = process
+        .copy_pointer(modules_ptr_ptr)
+        .context("Failed to copy modules PyObject")?;
+
+    for entry in DictIterator::from(process, version, modules as usize)
+        .context("Failed to read sys.modules")?
+    {
+        let (key, value) = entry?;
+        let Ok(module_name) = copy_string(key as *const I::StringObject, process) else {
+            continue;
+        };
+        if module_name != wanted {
+            continue;
+        }
+
+        let module: I::Object = process.copy_struct(value)?;
+        let module_type = process.copy_pointer(module.ob_type())?;
+        let dict_offset = module_type.dictoffset();
+        if dict_offset <= 0 {
+            return Err(format_err!("Module {wanted} has no readable dictionary"));
+        }
+        let dict: usize = process.copy_struct((value as isize + dict_offset) as usize)?;
+        return Ok(Some(dict));
+    }
+    Ok(None)
+}
+
+fn string_keyed_dict<I, P>(
+    process: &P,
+    version: &Version,
+    dict: usize,
+) -> Result<HashMap<String, usize>, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let mut values = HashMap::new();
+    for entry in DictIterator::from(process, version, dict)
+        .with_context(|| format!("Failed to read string-keyed dict at 0x{dict:x}"))?
+    {
+        let (key, value) = entry?;
+        if let Ok(name) = copy_string(key as *const I::StringObject, process) {
+            values.insert(name, value);
+        }
+    }
+    Ok(values)
+}
+
+fn object_attributes<I, P>(
+    process: &P,
+    version: &Version,
+    addr: usize,
+) -> Result<HashMap<String, usize>, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let object: I::Object = process.copy_struct(addr)?;
+    let object_type = process.copy_pointer(object.ob_type())?;
+    let flags = object_type.flags();
+
+    let iterator = if flags & PY_TPFLAGS_MANAGED_DICT != 0 {
+        DictIterator::from_managed_dict(process, version, addr, object.ob_type() as usize, flags)?
+    } else {
+        let dict_offset = object_type.dictoffset();
+        if dict_offset <= 0 {
+            return Err(format_err!(
+                "Object at 0x{addr:x} has no instance dictionary"
+            ));
+        }
+        let dict: usize = process.copy_struct((addr as isize + dict_offset) as usize)?;
+        if dict == 0 {
+            return Err(format_err!("Object at 0x{addr:x} has an empty dictionary"));
+        }
+        DictIterator::from(process, version, dict)?
+    };
+
+    let mut values = HashMap::new();
+    for entry in iterator {
+        let (key, value) = entry?;
+        if let Ok(name) = copy_string(key as *const I::StringObject, process) {
+            values.insert(name, value);
+        }
+    }
+    Ok(values)
+}
+
+fn weak_set_members<I, P>(
+    process: &P,
+    version: &Version,
+    weak_set: usize,
+) -> Result<Vec<usize>, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let attributes = object_attributes::<I, P>(process, version, weak_set)
+        .with_context(|| format!("Failed to read WeakSet at 0x{weak_set:x}"))?;
+    let data = *attributes
+        .get("data")
+        .ok_or_else(|| format_err!("asyncio WeakSet has no data attribute"))?;
+    let mut tasks = Vec::new();
+    for entry in SetIterator::from(process, data)? {
+        let weakref = entry?;
+        // PyWeakReference starts with PyObject_HEAD followed by wr_object.
+        let target: usize = process.copy_struct(weakref + 2 * std::mem::size_of::<usize>())?;
+        if target != 0 {
+            tasks.push(target);
+        }
+    }
+    Ok(tasks)
+}
+
+fn set_members<P: ProcessMemory>(process: &P, set: usize) -> Result<Vec<usize>, Error> {
+    SetIterator::from(process, set)?.collect()
+}
+
+fn registry_tasks<I, P>(
+    process: &P,
+    version: &Version,
+    module: &HashMap<String, usize>,
+) -> Result<Vec<usize>, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let mut tasks = Vec::new();
+    if let Some(registry) = module.get("_all_tasks") {
+        tasks.extend(
+            weak_set_members::<I, P>(process, version, *registry)
+                .context("Failed to read asyncio._all_tasks")?,
+        );
+    }
+    if let Some(registry) = module.get("_scheduled_tasks") {
+        tasks.extend(
+            weak_set_members::<I, P>(process, version, *registry)
+                .context("Failed to read asyncio._scheduled_tasks")?,
+        );
+    }
+    if let Some(registry) = module.get("_eager_tasks") {
+        tasks.extend(
+            set_members(process, *registry).context("Failed to read asyncio._eager_tasks")?,
+        );
+    }
+    Ok(tasks)
+}
+
+fn current_tasks<P: ProcessMemory>(
+    process: &P,
+    version: &Version,
+    module: &HashMap<String, usize>,
+) -> Result<HashSet<usize>, Error> {
+    let mut current = HashSet::new();
+    if let Some(tasks) = module.get("_current_tasks") {
+        for entry in DictIterator::from(process, version, *tasks)
+            .context("Failed to read asyncio._current_tasks")?
+        {
+            let (_, task) = entry?;
+            if task != 0 {
+                current.insert(task);
+            }
+        }
+    }
+    Ok(current)
+}
+
+fn linked_list_tasks<P: ProcessMemory>(
+    process: &P,
+    head: usize,
+    task_node_offset: usize,
+) -> Result<Vec<usize>, Error> {
+    let root: v3_14_0::llist_node = process.copy_struct(head)?;
+    let mut node = root.next as usize;
+    let mut seen = HashSet::new();
+    let mut tasks = Vec::new();
+    while node != 0 && node != head {
+        if !seen.insert(node) {
+            return Err(format_err!("Cycle in asyncio task list at 0x{node:x}"));
+        }
+        if tasks.len() >= MAX_TASKS {
+            return Err(format_err!(
+                "Refusing to read more than {MAX_TASKS} asyncio tasks"
+            ));
+        }
+        tasks.push(
+            node.checked_sub(task_node_offset)
+                .ok_or_else(|| format_err!("Invalid asyncio task node at 0x{node:x}"))?,
+        );
+        let entry: v3_14_0::llist_node = process.copy_struct(node)?;
+        node = entry.next as usize;
+    }
+    Ok(tasks)
+}
+
+fn python_314_tasks<P: ProcessMemory>(
+    interpreter_address: usize,
+    process: &P,
+    debug_offsets: &v3_14_0::_Py_DebugOffsets,
+    asyncio_offsets: &AsyncioDebugOffsets,
+) -> Result<(Vec<usize>, HashSet<usize>), Error> {
+    let node_offset = asyncio_offsets.task.node as usize;
+
+    let mut tasks = linked_list_tasks(
+        process,
+        interpreter_address + asyncio_offsets.interpreter.tasks_head as usize,
+        node_offset,
+    )
+    .context("Failed to read interpreter task list")?;
+    let mut current = HashSet::new();
+
+    let thread_head_ptr =
+        interpreter_address + debug_offsets.interpreter_state.threads_head as usize;
+    let mut thread: *mut v3_14_0::PyThreadState = process
+        .copy_struct(thread_head_ptr)
+        .context("Failed to read Python thread list head")?;
+    while !thread.is_null() {
+        let thread_addr = thread as usize;
+        let task_head = thread_addr + asyncio_offsets.thread.tasks_head as usize;
+        tasks.extend(
+            linked_list_tasks(process, task_head, node_offset).with_context(|| {
+                format!("Failed to read task list for thread 0x{thread_addr:x}")
+            })?,
+        );
+
+        let running: usize = process
+            .copy_struct(thread_addr + asyncio_offsets.thread.running_task as usize)
+            .context("Failed to read running asyncio task")?;
+        if running != 0 {
+            current.insert(running);
+        }
+
+        thread = process
+            .copy_struct(thread_addr + debug_offsets.thread_state.next as usize)
+            .context("Failed to read next Python thread state")?;
+    }
+    Ok((tasks, current))
+}
+
+fn read_task_name<I, P>(process: &P, version: &Version, name: usize) -> Option<String>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    if name == 0 {
+        return None;
+    }
+    match copy_type_name::<I, P>(process, name).ok()?.as_str() {
+        "str" => copy_string(name as *const I::StringObject, process).ok(),
+        "int" => copy_long(process, version, name)
+            .ok()
+            .map(|(value, _)| format!("Task-{value}")),
+        _ => format_variable::<I, P>(process, version, name, 128).ok(),
+    }
+}
+
+fn read_creation_traceback<I, P>(
+    process: &P,
+    version: &Version,
+    source_traceback: usize,
+) -> Result<Option<Vec<Frame>>, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    if source_traceback == 0 {
+        return Ok(None);
+    }
+
+    // Pure-Python Task implementations store None when debug capture was off.
+    if matches!(
+        copy_type_name::<I, P>(process, source_traceback).as_deref(),
+        Ok("NoneType")
+    ) {
+        return Ok(None);
+    }
+
+    let offsets = frame_summary_offsets(version)
+        .ok_or_else(|| format_err!("Unsupported FrameSummary layout on Python {version}"))?;
+    let summary: I::ListObject = process
+        .copy_struct(source_traceback)
+        .context("Failed to read task creation StackSummary")?;
+    let count = summary.size();
+    if count > MAX_CREATION_FRAMES {
+        return Err(format_err!(
+            "Refusing to read more than {MAX_CREATION_FRAMES} task creation frames"
+        ));
+    }
+
+    let mut frames = Vec::with_capacity(count);
+    for index in 0..count {
+        let item: usize = process
+            .copy_struct(summary.item() as usize + index * std::mem::size_of::<usize>())
+            .with_context(|| format!("Failed to read creation frame {index}"))?;
+        if item == 0 {
+            continue;
+        }
+
+        let filename_ptr: usize = process.copy_struct(item + offsets.filename)?;
+        let lineno_ptr: usize = process.copy_struct(item + offsets.lineno)?;
+        let name_ptr: usize = process.copy_struct(item + offsets.name)?;
+        let filename = copy_string(filename_ptr as *const I::StringObject, process)
+            .with_context(|| format!("Failed to read filename for creation frame {index}"))?;
+        let name = copy_string(name_ptr as *const I::StringObject, process)
+            .with_context(|| format!("Failed to read name for creation frame {index}"))?;
+        let line = copy_long(process, version, lineno_ptr)
+            .with_context(|| format!("Failed to read line number for creation frame {index}"))?
+            .0
+            .try_into()
+            .unwrap_or(0);
+
+        frames.push(Frame {
+            name,
+            filename,
+            module: None,
+            short_filename: None,
+            line,
+            locals: None,
+            is_entry: false,
+            is_shim_entry: false,
+        });
+    }
+    Ok(Some(frames))
+}
+
+fn read_task<I, P>(
+    process: &P,
+    version: &Version,
+    task: usize,
+    running: bool,
+    copy_locals: bool,
+    lineno: LineNo,
+    inspection_offsets: InspectionOffsets<'_>,
+) -> Result<AsyncioTask, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let mut offsets = task_offsets(version)
+        .ok_or_else(|| format_err!("asyncio task inspection is unsupported on Python {version}"))?;
+    if let Some(asyncio_offsets) = inspection_offsets.asyncio {
+        offsets.coro = asyncio_offsets.task.coro as usize;
+        offsets.name = Some(asyncio_offsets.task.name as usize);
+    }
+
+    // Pure-Python Task implementations expose these fields through their
+    // instance dictionary. Native _asyncio.Task objects use the C offsets.
+    let task_type = copy_type_name::<I, P>(process, task).unwrap_or_default();
+    let attributes = if task_type == "_asyncio.Task" {
+        None
+    } else {
+        object_attributes::<I, P>(process, version, task).ok()
+    };
+    let coro = match attributes.as_ref().and_then(|attrs| attrs.get("_coro")) {
+        Some(coro) => *coro,
+        None => process.copy_struct(task + offsets.coro)?,
+    };
+    let name_ptr = attributes
+        .as_ref()
+        .and_then(|attrs| attrs.get("_name"))
+        .copied()
+        .or_else(|| {
+            offsets
+                .name
+                .and_then(|offset| process.copy_struct(task + offset).ok())
+        });
+    let source_traceback_ptr = match attributes
+        .as_ref()
+        .and_then(|attrs| attrs.get("_source_traceback"))
+    {
+        Some(source_traceback) => *source_traceback,
+        None => process.copy_struct(task + offsets.source_traceback)?,
+    };
+    let creation_traceback =
+        match read_creation_traceback::<I, P>(process, version, source_traceback_ptr) {
+            Ok(traceback) => traceback,
+            Err(error) => {
+                warn!(
+                    "Failed to inspect creation traceback for asyncio task at 0x{task:x}: {error}"
+                );
+                None
+            }
+        };
+
+    let state = if running {
+        "running".to_owned()
+    } else if let Some(state) = attributes
+        .as_ref()
+        .and_then(|attrs| attrs.get("_state"))
+        .and_then(|state| copy_string(*state as *const I::StringObject, process).ok())
+    {
+        state.to_ascii_lowercase()
+    } else if version.minor == 14 {
+        // Native 3.14 task lists only contain pending tasks. Future state is
+        // intentionally not part of CPython's AsyncioDebug table.
+        "pending".to_owned()
+    } else {
+        let state: i32 = process.copy_struct(task + offsets.state)?;
+        match state {
+            0 => "pending",
+            1 => "cancelled",
+            2 => "finished",
+            _ => "unknown",
+        }
+        .to_owned()
+    };
+
+    let frames = if coro == 0 {
+        Vec::new()
+    } else {
+        let coro_type = copy_type_name::<I, P>(process, coro).unwrap_or_default();
+        if matches!(
+            coro_type.as_str(),
+            "coroutine" | "generator" | "async_generator"
+        ) {
+            let frame_offset = inspection_offsets
+                .python
+                .map(|offsets| offsets.gen_object.gi_iframe as usize)
+                .or_else(|| coroutine_frame_offset(version))
+                .unwrap();
+            let frame_addr = if version.minor <= 10 {
+                process.copy_struct(coro + frame_offset)?
+            } else {
+                coro + frame_offset
+            };
+            let mut frames = get_stack_frames(
+                frame_addr as *mut <I::ThreadState as ThreadState>::FrameObject,
+                process,
+                copy_locals,
+                lineno,
+            )?;
+            // A coroutine owns one current frame. When it is actively running,
+            // f_back may lead into the event loop's thread stack; those frames
+            // belong to the runner, not to this task.
+            frames.truncate(1);
+            frames
+        } else {
+            Vec::new()
+        }
+    };
+
+    Ok(AsyncioTask {
+        task_id: format!("0x{task:x}"),
+        name: name_ptr.and_then(|name| read_task_name::<I, P>(process, version, name)),
+        state,
+        frames,
+        creation_traceback,
+    })
+}
+
+/// Returns every live asyncio task registered in the interpreter.
+pub(crate) fn tasks_from_interpreter<I, P>(
+    interpreter_address: usize,
+    process: &P,
+    version: &Version,
+    copy_locals: bool,
+    lineno: LineNo,
+    debug_offsets: Option<&v3_14_0::_Py_DebugOffsets>,
+    asyncio_offsets: Option<&AsyncioDebugOffsets>,
+) -> Result<Vec<AsyncioTask>, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    if version.major != 3 || !(7..=14).contains(&version.minor) {
+        return Err(format_err!(
+            "asyncio task inspection requires CPython 3.7 through 3.14 (found {version})"
+        ));
+    }
+
+    let Some(module_dict) = module_dict::<I, P>(
+        interpreter_address,
+        process,
+        version,
+        "asyncio.tasks",
+        debug_offsets,
+    )
+    .context("Failed to locate asyncio.tasks")?
+    else {
+        return Ok(Vec::new());
+    };
+    let module = string_keyed_dict::<I, P>(process, version, module_dict)
+        .context("Failed to read asyncio.tasks module dictionary")?;
+    let mut task_addresses = registry_tasks::<I, P>(process, version, &module)
+        .context("Failed to read asyncio task registries")?;
+    let mut running =
+        current_tasks(process, version, &module).context("Failed to read current asyncio tasks")?;
+
+    if version.minor == 14 {
+        let debug_offsets = debug_offsets
+            .ok_or_else(|| format_err!("Python 3.14 runtime debug offsets are unavailable"))?;
+        let asyncio_offsets = asyncio_offsets
+            .ok_or_else(|| format_err!("Python 3.14 asyncio debug offsets are unavailable"))?;
+        let (native_tasks, native_running) =
+            python_314_tasks(interpreter_address, process, debug_offsets, asyncio_offsets)
+                .context("Failed to read Python 3.14 native task lists")?;
+        task_addresses.extend(native_tasks);
+        running.extend(native_running);
+    }
+
+    task_addresses.sort_unstable();
+    task_addresses.dedup();
+    if task_addresses.len() > MAX_TASKS {
+        return Err(format_err!(
+            "Refusing to read more than {MAX_TASKS} asyncio tasks"
+        ));
+    }
+
+    let mut tasks = Vec::with_capacity(task_addresses.len());
+    let inspection_offsets = InspectionOffsets {
+        python: debug_offsets,
+        asyncio: asyncio_offsets,
+    };
+    for task in task_addresses {
+        match read_task::<I, P>(
+            process,
+            version,
+            task,
+            running.contains(&task),
+            copy_locals,
+            lineno,
+            inspection_offsets,
+        ) {
+            Ok(task) => tasks.push(task),
+            Err(error) => warn!("Failed to inspect asyncio task at 0x{task:x}: {error}"),
+        }
+    }
+    Ok(tasks)
+}

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -127,6 +127,12 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                             }
                         }
                     }
+
+                    if name == "AsyncioDebug" {
+                        if let Some(addr) = section.addr.checked_add(offset) {
+                            symbols.insert("AsyncioDebug".to_owned(), addr);
+                        }
+                    }
                 }
             }
 
@@ -221,6 +227,16 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                 }
             }
 
+            if let Some(header) = elf
+                .section_headers
+                .iter()
+                .find(|header| strtab.get_at(header.sh_name) == Some(".AsyncioDebug"))
+            {
+                if let Some(addr) = header.sh_addr.checked_add(offset) {
+                    symbols.insert("AsyncioDebug".to_owned(), addr);
+                }
+            }
+
             for sym in elf.syms.iter() {
                 // Skip undefined symbols.
                 if sym.st_shndx == goblin::elf::section_header::SHN_UNDEF as usize {
@@ -307,6 +323,10 @@ pub fn parse_binary(filename: &Path, addr: u64, size: u64) -> Result<BinaryInfo,
                             pyruntime_addr = addr;
                             pyruntime_size = u64::from(section.virtual_size);
                         }
+                    }
+                } else if section.name.starts_with(b"AsyncioD") {
+                    if let Some(addr) = offset.checked_add(section.virtual_address as u64) {
+                        symbols.insert("AsyncioDebug".to_owned(), addr);
                     }
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,8 @@ pub struct Config {
     #[doc(hidden)]
     pub dump_locals: u64,
     #[doc(hidden)]
+    pub dump_asyncio: bool,
+    #[doc(hidden)]
     pub full_filenames: bool,
     #[doc(hidden)]
     pub lineno: LineNo,
@@ -130,6 +132,7 @@ impl Default for Config {
             capture_output: true,
             dump_json: false,
             dump_locals: 0,
+            dump_asyncio: false,
             subprocesses: false,
             full_filenames: false,
             lineno: LineNo::LastInstruction,
@@ -329,6 +332,10 @@ impl Config {
                 .long("json")
                 .help("Format output as JSON")
                 .action(ArgAction::SetTrue))
+            .arg(Arg::new("asyncio")
+                .long("asyncio")
+                .help("Also dump live asyncio tasks, suspended frames, and creation tracebacks")
+                .action(ArgAction::SetTrue))
             .arg(subprocesses.clone());
 
         let completions = Command::new("completions")
@@ -419,6 +426,7 @@ impl Config {
             "dump" => {
                 config.dump_json = matches.get_flag("json");
                 config.dump_locals = matches.get_count("locals").into();
+                config.dump_asyncio = matches.get_flag("asyncio");
 
                 #[cfg(target_os = "linux")]
                 {
@@ -571,6 +579,10 @@ mod tests {
         let config = get_config("py-spy dump --pid 1234").unwrap();
         assert_eq!(config.pid, Some(1234));
         assert_eq!(config.command, String::from("dump"));
+        assert!(!config.dump_asyncio);
+
+        let asyncio_config = get_config("py-spy dump --asyncio --pid 1234").unwrap();
+        assert!(asyncio_config.dump_asyncio);
 
         // short version
         let short_config = get_config("py-spy d -p 1234").unwrap();

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -5,7 +5,7 @@ use console::{style, Term};
 
 use crate::config::Config;
 use crate::python_spy::PythonSpy;
-use crate::stack_trace::StackTrace;
+use crate::stack_trace::{Frame, StackTrace};
 
 use remoteprocess::Pid;
 
@@ -26,7 +26,18 @@ pub fn write_traces<W: Write>(
         let traces = process
             .get_stack_traces()
             .context("Failed to get stack traces")?;
-        writeln!(out, "{}", serde_json::to_string_pretty(&traces)?)?;
+        if config.dump_asyncio {
+            let tasks = process
+                .get_asyncio_tasks()
+                .context("Failed to get asyncio tasks")?;
+            let output = serde_json::json!({
+                "threads": traces,
+                "asyncio_tasks": tasks,
+            });
+            writeln!(out, "{}", serde_json::to_string_pretty(&output)?)?;
+        } else {
+            writeln!(out, "{}", serde_json::to_string_pretty(&traces)?)?;
+        }
         return Ok(());
     }
 
@@ -59,6 +70,36 @@ pub fn write_traces<W: Write>(
         .context("Failed to get stack traces")?;
     for trace in traces.iter().rev() {
         write_trace(out, trace, true)?;
+    }
+
+    if config.dump_asyncio {
+        let tasks = process
+            .get_asyncio_tasks()
+            .context("Failed to get asyncio tasks")?;
+        writeln!(out, "\nAsyncio Tasks ({})", tasks.len())?;
+        for task in &tasks {
+            let name = task
+                .name
+                .as_ref()
+                .map(|name| format!(" \"{name}\""))
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "Task {}{} ({})",
+                style(&task.task_id).bold().yellow(),
+                name,
+                task.state
+            )?;
+            for frame in &task.frames {
+                write_frame(out, frame)?;
+            }
+            if let Some(frames) = &task.creation_traceback {
+                writeln!(out, "    Created at:")?;
+                for frame in frames {
+                    write_frame_indented(out, frame, "        ")?;
+                }
+            }
+        }
     }
 
     if config.subprocesses {
@@ -121,42 +162,53 @@ pub fn write_trace<W: Write>(
     };
 
     for frame in &trace.frames {
-        let filename = match &frame.short_filename {
-            Some(f) => f,
-            None => &frame.filename,
-        };
-        if frame.line != 0 {
-            writeln!(
-                out,
-                "    {} ({}:{})",
-                style(&frame.name).green(),
-                style(&filename).cyan(),
-                style(frame.line).dim()
-            )?;
-        } else {
-            writeln!(
-                out,
-                "    {} ({})",
-                style(&frame.name).green(),
-                style(&filename).cyan()
-            )?;
-        }
+        write_frame(out, frame)?;
+    }
+    Ok(())
+}
 
-        if let Some(locals) = &frame.locals {
-            let mut shown_args = false;
-            let mut shown_locals = false;
-            for local in locals {
-                if local.arg && !shown_args {
-                    writeln!(out, "        {}", style("Arguments:").dim())?;
-                    shown_args = true;
-                } else if !local.arg && !shown_locals {
-                    writeln!(out, "        {}", style("Locals:").dim())?;
-                    shown_locals = true;
-                }
+fn write_frame<W: Write>(out: &mut W, frame: &Frame) -> Result<(), Error> {
+    write_frame_indented(out, frame, "    ")
+}
 
-                let repr = local.repr.as_deref().unwrap_or("?");
-                writeln!(out, "            {}: {}", local.name, repr)?;
+fn write_frame_indented<W: Write>(out: &mut W, frame: &Frame, indent: &str) -> Result<(), Error> {
+    let filename = match &frame.short_filename {
+        Some(f) => f,
+        None => &frame.filename,
+    };
+    if frame.line != 0 {
+        writeln!(
+            out,
+            "{}{} ({}:{})",
+            indent,
+            style(&frame.name).green(),
+            style(&filename).cyan(),
+            style(frame.line).dim()
+        )?;
+    } else {
+        writeln!(
+            out,
+            "{}{} ({})",
+            indent,
+            style(&frame.name).green(),
+            style(&filename).cyan()
+        )?;
+    }
+
+    if let Some(locals) = &frame.locals {
+        let mut shown_args = false;
+        let mut shown_locals = false;
+        for local in locals {
+            if local.arg && !shown_args {
+                writeln!(out, "{}    {}", indent, style("Arguments:").dim())?;
+                shown_args = true;
+            } else if !local.arg && !shown_locals {
+                writeln!(out, "{}    {}", indent, style("Locals:").dim())?;
+                shown_locals = true;
             }
+
+            let repr = local.repr.as_deref().unwrap_or("?");
+            writeln!(out, "{}        {}: {}", indent, local.name, repr)?;
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ extern crate anyhow;
 #[macro_use]
 extern crate log;
 
+pub mod asyncio;
 pub mod binary_parser;
 pub mod config;
 #[cfg(all(target_os = "linux", feature = "cli"))]
@@ -51,6 +52,7 @@ pub mod timer;
 mod utils;
 mod version;
 
+pub use asyncio::AsyncioTask;
 pub use config::Config;
 pub use python_spy::PythonSpy;
 pub use remoteprocess::Pid;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate anyhow;
 #[macro_use]
 extern crate log;
 
+mod asyncio;
 mod binary_parser;
 mod chrometrace;
 mod config;
@@ -400,6 +401,11 @@ fn pyspy_main() -> Result<(), Error> {
     #[cfg(target_os = "linux")]
     {
         if let Some(ref core_filename) = config.core_filename {
+            if config.dump_asyncio {
+                return Err(format_err!(
+                    "--asyncio currently supports live processes, not core dumps"
+                ));
+            }
             let core = coredump::PythonCoreDump::new(std::path::Path::new(&core_filename))?;
             let traces = core.get_stack(&config)?;
             return core.print_traces(&traces, &config);

--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unnecessary_cast)]
-use anyhow::Error;
+use anyhow::{Context, Error};
 
 use crate::python_bindings::v3_13_0;
 use crate::python_interpreters::{
@@ -8,6 +8,24 @@ use crate::python_interpreters::{
 use crate::utils::offset_of;
 use crate::version::Version;
 use remoteprocess::ProcessMemory;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct SetObjectHeader {
+    ob_refcnt: isize,
+    ob_type: usize,
+    fill: isize,
+    used: isize,
+    mask: isize,
+    table: usize,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct SetEntry {
+    key: usize,
+    hash: isize,
+}
 
 /// Copies a string from a target process. Attempts to handle unicode differences, which mostly seems to be working
 pub fn copy_string<T: StringObject, P: ProcessMemory>(
@@ -151,6 +169,25 @@ pub struct DictIterator<'a, P: 'a> {
     values: usize,
 }
 
+fn dict_entries_address(
+    keys_addr: usize,
+    log2_index_bytes: u8,
+    keys_header_size: usize,
+    entries: isize,
+) -> Result<(usize, usize), Error> {
+    if log2_index_bytes > 32 || entries < 0 || entries > (1 << 24) {
+        return Err(format_err!(
+            "Invalid dict metadata: dk_log2_index_bytes={log2_index_bytes}, dk_nentries={entries}"
+        ));
+    }
+    let index_bytes = 1usize << log2_index_bytes;
+    let address = keys_addr
+        .checked_add(index_bytes)
+        .and_then(|addr| addr.checked_add(keys_header_size))
+        .ok_or_else(|| format_err!("Dictionary entries address overflow"))?;
+    Ok((address, entries as usize))
+}
+
 impl<'a, P: ProcessMemory> DictIterator<'a, P> {
     pub fn from_managed_dict(
         process: &'a P,
@@ -178,14 +215,27 @@ impl<'a, P: ProcessMemory> DictIterator<'a, P> {
         }
 
         if values_addr != 0 {
-            let ht_cached_keys = if version.major == 3 && version.minor >= 12 {
-                let ht: crate::python_bindings::v3_12_0::PyHeapTypeObject =
-                    process.copy_struct(tp_addr)?;
-                ht.ht_cached_keys as usize
-            } else {
-                let ht: crate::python_bindings::v3_11_0::PyHeapTypeObject =
-                    process.copy_struct(tp_addr)?;
-                ht.ht_cached_keys as usize
+            let ht_cached_keys = match (version.major, version.minor) {
+                (3, 14) => {
+                    let ht: crate::python_bindings::v3_14_0::PyHeapTypeObject =
+                        process.copy_struct(tp_addr)?;
+                    ht.ht_cached_keys as usize
+                }
+                (3, 13) => {
+                    let ht: crate::python_bindings::v3_13_0::PyHeapTypeObject =
+                        process.copy_struct(tp_addr)?;
+                    ht.ht_cached_keys as usize
+                }
+                (3, 12) => {
+                    let ht: crate::python_bindings::v3_12_0::PyHeapTypeObject =
+                        process.copy_struct(tp_addr)?;
+                    ht.ht_cached_keys as usize
+                }
+                _ => {
+                    let ht: crate::python_bindings::v3_11_0::PyHeapTypeObject =
+                        process.copy_struct(tp_addr)?;
+                    ht.ht_cached_keys as usize
+                }
             };
 
             // handle inline values in py3.13+
@@ -201,15 +251,18 @@ impl<'a, P: ProcessMemory> DictIterator<'a, P> {
             let keys: crate::python_bindings::v3_12_0::PyDictKeysObject =
                 process.copy_struct(ht_cached_keys as usize)?;
 
-            let entries_addr = ht_cached_keys as usize
-                + (1 << keys.dk_log2_index_bytes)
-                + std::mem::size_of_val(&keys);
+            let (entries_addr, entries) = dict_entries_address(
+                ht_cached_keys,
+                keys.dk_log2_index_bytes,
+                std::mem::size_of_val(&keys),
+                keys.dk_nentries,
+            )?;
             Ok(DictIterator {
                 process,
                 entries_addr,
                 index: 0,
                 kind: keys.dk_kind,
-                entries: keys.dk_nentries as usize,
+                entries,
                 values: values_addr,
             })
         } else if dict_addr != 0 {
@@ -227,22 +280,50 @@ impl<'a, P: ProcessMemory> DictIterator<'a, P> {
         match version {
             Version {
                 major: 3,
-                minor: 11..=14,
+                minor: 14,
                 ..
             } => {
-                let dict: crate::python_bindings::v3_11_0::PyDictObject =
+                let dict: crate::python_bindings::v3_14_0::PyDictObject =
                     process.copy_struct(addr)?;
-                let keys = process.copy_pointer(dict.ma_keys)?;
-
-                let entries_addr = dict.ma_keys as usize
-                    + (1 << keys.dk_log2_index_bytes)
-                    + std::mem::size_of_val(&keys);
+                let keys: crate::python_bindings::v3_11_0::_dictkeysobject =
+                    process.copy_struct(dict.ma_keys as usize)?;
+                let (entries_addr, entries) = dict_entries_address(
+                    dict.ma_keys as usize,
+                    keys.dk_log2_index_bytes,
+                    std::mem::size_of_val(&keys),
+                    keys.dk_nentries,
+                )
+                .with_context(|| format!("Invalid Python 3.14 dict at 0x{addr:x}"))?;
                 Ok(DictIterator {
                     process,
                     entries_addr,
                     index: 0,
                     kind: keys.dk_kind,
-                    entries: keys.dk_nentries as usize,
+                    entries,
+                    values: dict.ma_values as usize,
+                })
+            }
+            Version {
+                major: 3,
+                minor: 11..=13,
+                ..
+            } => {
+                let dict: crate::python_bindings::v3_11_0::PyDictObject =
+                    process.copy_struct(addr)?;
+                let keys = process.copy_pointer(dict.ma_keys)?;
+                let (entries_addr, entries) = dict_entries_address(
+                    dict.ma_keys as usize,
+                    keys.dk_log2_index_bytes,
+                    std::mem::size_of_val(&keys),
+                    keys.dk_nentries,
+                )
+                .with_context(|| format!("Invalid Python dict at 0x{addr:x}"))?;
+                Ok(DictIterator {
+                    process,
+                    entries_addr,
+                    index: 0,
+                    kind: keys.dk_kind,
+                    entries,
                     values: dict.ma_values as usize,
                 })
             }
@@ -342,6 +423,55 @@ impl<'a, P: ProcessMemory> Iterator for DictIterator<'a, P> {
     }
 }
 
+/// Allows iteration of a Python set without executing code in the target process.
+/// The portion of PySetObject used here is stable across all supported CPython 3.x
+/// versions.
+pub struct SetIterator<'a, P: 'a> {
+    process: &'a P,
+    table: usize,
+    index: usize,
+    entries: usize,
+}
+
+impl<'a, P: ProcessMemory> SetIterator<'a, P> {
+    pub fn from(process: &'a P, addr: usize) -> Result<SetIterator<'a, P>, Error> {
+        let set: SetObjectHeader = process.copy_struct(addr)?;
+        if set.mask < 0 || set.mask > (1 << 24) || set.used < 0 || set.used > set.mask + 1 {
+            return Err(format_err!(
+                "Invalid set metadata at 0x{addr:x}: used={}, mask={}",
+                set.used,
+                set.mask
+            ));
+        }
+        if set.table == 0 {
+            return Err(format_err!("Set at 0x{addr:x} has a null table"));
+        }
+        Ok(SetIterator {
+            process,
+            table: set.table,
+            index: 0,
+            entries: set.mask as usize + 1,
+        })
+    }
+}
+
+impl<'a, P: ProcessMemory> Iterator for SetIterator<'a, P> {
+    type Item = Result<usize, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.index < self.entries {
+            let addr = self.table + self.index * std::mem::size_of::<SetEntry>();
+            self.index += 1;
+            match self.process.copy_struct::<SetEntry>(addr) {
+                Ok(entry) if entry.key != 0 && entry.hash != -1 => return Some(Ok(entry.key)),
+                Ok(_) => continue,
+                Err(err) => return Some(Err(err.into())),
+            }
+        }
+        None
+    }
+}
+
 pub const PY_TPFLAGS_INLINE_VALUES: usize = 1 << 2;
 pub const PY_TPFLAGS_MANAGED_DICT: usize = 1 << 4;
 const PY_TPFLAGS_INT_SUBCLASS: usize = 1 << 23;
@@ -351,6 +481,19 @@ const PY_TPFLAGS_TUPLE_SUBCLASS: usize = 1 << 26;
 const PY_TPFLAGS_BYTES_SUBCLASS: usize = 1 << 27;
 const PY_TPFLAGS_STRING_SUBCLASS: usize = 1 << 28;
 const PY_TPFLAGS_DICT_SUBCLASS: usize = 1 << 29;
+
+/// Returns the CPython type name for an object in the target process.
+pub fn copy_type_name<I, P>(process: &P, addr: usize) -> Result<String, Error>
+where
+    I: InterpreterState,
+    P: ProcessMemory,
+{
+    let value: I::Object = process.copy_struct(addr)?;
+    let value_type = process.copy_pointer(value.ob_type())?;
+    let bytes = process.copy(value_type.name() as usize, 128)?;
+    let length = bytes.iter().position(|&x| x == 0).unwrap_or(bytes.len());
+    Ok(std::str::from_utf8(&bytes[..length])?.to_owned())
+}
 
 /// Converts a python variable in the other process to a human readable string
 pub fn format_variable<I, P>(
@@ -373,13 +516,8 @@ where
     let value_type = process.copy_pointer(value.ob_type())?;
 
     // get the typename (truncating to 128 bytes if longer)
-    let max_type_len = 128;
-    let value_type_name = process.copy(value_type.name() as usize, max_type_len)?;
-    let length = value_type_name
-        .iter()
-        .position(|&x| x == 0)
-        .unwrap_or(max_type_len);
-    let value_type_name = std::str::from_utf8(&value_type_name[..length])?;
+    let value_type_name = copy_type_name::<I, P>(process, addr)?;
+    let value_type_name = value_type_name.as_str();
 
     let format_int = |value: i64| {
         if value_type_name == "bool" {

--- a/src/python_process_info.rs
+++ b/src/python_process_info.rs
@@ -33,6 +33,8 @@ pub struct PythonProcessInfo {
     pub libpython_binary: Option<BinaryInfo>,
     pub maps: Box<dyn ContainsAddr>,
     pub python_filename: std::path::PathBuf,
+    /// Address of CPython 3.14's AsyncioDebug section, when _asyncio is loaded.
+    pub asyncio_debug_address: Option<u64>,
     #[cfg(target_os = "linux")]
     pub dockerized: bool,
 }
@@ -259,6 +261,45 @@ impl PythonProcessInfo {
             _ => python_binary.ok(),
         };
 
+        // Python 3.14 publishes task and task-list offsets in a dedicated
+        // section of the dynamically loaded _asyncio extension. Locate it so
+        // out-of-process inspection remains stable across patch releases.
+        let asyncio_debug_address = python_binary
+            .as_ref()
+            .and_then(|binary| binary.symbols.get("AsyncioDebug"))
+            .or_else(|| {
+                libpython_binary
+                    .as_ref()
+                    .and_then(|binary| binary.symbols.get("AsyncioDebug"))
+            })
+            .copied()
+            .or_else(|| {
+                maps.iter()
+                    .filter(|map| map.is_exec())
+                    .filter_map(|map| map.filename().map(|filename| (map, filename)))
+                    .find_map(|(map, filename)| {
+                        let basename = filename.file_name()?.to_str()?;
+                        if !basename.starts_with("_asyncio.") {
+                            return None;
+                        }
+
+                        #[cfg(target_os = "linux")]
+                        let parse_filename = std::path::PathBuf::from(format!(
+                            "/proc/{}/root{}",
+                            process.pid,
+                            filename.display()
+                        ));
+                        #[cfg(not(target_os = "linux"))]
+                        let parse_filename = filename.to_path_buf();
+
+                        parse_binary(&parse_filename, map.start() as u64, map.size() as u64)
+                            .ok()?
+                            .symbols
+                            .get("AsyncioDebug")
+                            .copied()
+                    })
+            });
+
         #[cfg(target_os = "linux")]
         let dockerized = is_dockerized(process.pid).unwrap_or(false);
 
@@ -267,6 +308,7 @@ impl PythonProcessInfo {
             libpython_binary,
             maps: Box::new(maps),
             python_filename,
+            asyncio_debug_address,
             #[cfg(target_os = "linux")]
             dockerized,
         })

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use anyhow::{Context, Error, Result};
 use remoteprocess::{Pid, Process, ProcessMemory, Tid};
 
+use crate::asyncio::{tasks_from_interpreter, AsyncioDebugOffsets, AsyncioTask};
 use crate::config::{Config, LockingStrategy};
 #[cfg(feature = "unwind")]
 use crate::native_stack_trace::NativeStack;
@@ -37,6 +38,8 @@ pub struct PythonSpy {
     pub short_filenames: HashMap<String, Option<String>>,
     pub python_thread_ids: HashMap<u64, Tid>,
     pub python_thread_names: HashMap<u64, String>,
+    python_debug_offsets: Option<v3_14_0::_Py_DebugOffsets>,
+    asyncio_debug_offsets: Option<AsyncioDebugOffsets>,
     #[cfg(target_os = "linux")]
     pub dockerized: bool,
 }
@@ -71,6 +74,36 @@ impl PythonSpy {
             config,
         )?;
 
+        let python_debug_offsets = if version.major == 3 && version.minor == 14 {
+            python_info
+                .get_symbol("_PyRuntime")
+                .and_then(|address| {
+                    process
+                        .copy_struct::<v3_14_0::_Py_DebugOffsets>(*address as usize)
+                        .ok()
+                })
+                .filter(|offsets| {
+                    offsets.cookie
+                        == [
+                            b'x' as i8, b'd' as i8, b'e' as i8, b'b' as i8, b'u' as i8, b'g' as i8,
+                            b'p' as i8, b'y' as i8,
+                        ]
+                })
+        } else {
+            None
+        };
+        let asyncio_debug_offsets = python_info
+            .asyncio_debug_address
+            .and_then(|address| {
+                process
+                    .copy_struct::<AsyncioDebugOffsets>(address as usize)
+                    .ok()
+            })
+            .filter(AsyncioDebugOffsets::is_sane);
+
+        #[cfg(target_os = "linux")]
+        let dockerized = python_info.dockerized;
+
         #[cfg(feature = "unwind")]
         let native = if config.native {
             Some(NativeStack::new(
@@ -91,11 +124,13 @@ impl PythonSpy {
             #[cfg(feature = "unwind")]
             native,
             #[cfg(target_os = "linux")]
-            dockerized: python_info.dockerized,
+            dockerized,
             config: config.clone(),
             short_filenames: HashMap::new(),
             python_thread_ids: HashMap::new(),
             python_thread_names: HashMap::new(),
+            python_debug_offsets,
+            asyncio_debug_offsets,
         })
     }
 
@@ -187,6 +222,93 @@ impl PythonSpy {
                 self.version
             )),
         }
+    }
+
+    /// Gets every live asyncio task and the frame at which its coroutine is
+    /// currently running or suspended. This never executes code in the target.
+    pub fn get_asyncio_tasks(&mut self) -> Result<Vec<AsyncioTask>, Error> {
+        match self.version {
+            Version {
+                major: 3, minor: 7, ..
+            } => self._get_asyncio_tasks::<v3_7_0::_is>(),
+            Version {
+                major: 3, minor: 8, ..
+            } => self._get_asyncio_tasks::<v3_8_0::_is>(),
+            Version {
+                major: 3, minor: 9, ..
+            } => self._get_asyncio_tasks::<v3_9_5::_is>(),
+            Version {
+                major: 3,
+                minor: 10,
+                ..
+            } => self._get_asyncio_tasks::<v3_10_0::_is>(),
+            Version {
+                major: 3,
+                minor: 11,
+                ..
+            } => self._get_asyncio_tasks::<v3_11_0::_is>(),
+            Version {
+                major: 3,
+                minor: 12,
+                ..
+            } => self._get_asyncio_tasks::<v3_12_0::_is>(),
+            Version {
+                major: 3,
+                minor: 13,
+                ..
+            } => self._get_asyncio_tasks::<v3_13_0::_is>(),
+            Version {
+                major: 3,
+                minor: 14,
+                ..
+            } => self._get_asyncio_tasks::<v3_14_0::_is>(),
+            _ => Err(format_err!(
+                "asyncio task inspection requires CPython 3.7 through 3.14 (found {})",
+                self.version
+            )),
+        }
+    }
+
+    fn _get_asyncio_tasks<I: InterpreterState>(&mut self) -> Result<Vec<AsyncioTask>, Error> {
+        let _lock = if self.config.blocking == LockingStrategy::Lock {
+            Some(self.process.lock().context("Failed to suspend process")?)
+        } else {
+            None
+        };
+
+        let mut tasks = tasks_from_interpreter::<I, Process>(
+            self.interpreter_address,
+            &self.process,
+            &self.version,
+            self.config.dump_locals > 0,
+            self.config.lineno,
+            self.python_debug_offsets.as_ref(),
+            self.asyncio_debug_offsets.as_ref(),
+        )?;
+
+        for task in &mut tasks {
+            if let Some(frames) = task.creation_traceback.as_mut() {
+                for frame in frames {
+                    frame.short_filename = self.shorten_filename(&frame.filename);
+                }
+            }
+            for frame in &mut task.frames {
+                frame.short_filename = self.shorten_filename(&frame.filename);
+                if let Some(locals) = frame.locals.as_mut() {
+                    let max_length = (128 * self.config.dump_locals) as isize;
+                    for local in locals {
+                        let repr = format_variable::<I, Process>(
+                            &self.process,
+                            &self.version,
+                            local.addr,
+                            max_length,
+                        );
+                        local.repr = Some(repr.unwrap_or_else(|_| "?".to_owned()));
+                    }
+                }
+            }
+        }
+        Ok(tasks)
     }
 
     // implementation of get_stack_traces, where we have a type for the InterpreterState

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -120,16 +120,40 @@ where
     T: ThreadState,
     P: ProcessMemory,
 {
-    // TODO: just return frames here? everything else probably should be returned out of scope
-    let mut frames = Vec::new();
-
     // python 3.11+ has an extra level of indirection to get the Frame from the threadstate
     let mut frame_address = thread.frame_address();
     if let Some(addr) = frame_address {
         frame_address = Some(process.copy_struct(addr)?);
     }
 
-    let mut frame_ptr = thread.frame(frame_address);
+    let frame_ptr = thread.frame(frame_address);
+    let frames = get_stack_frames(frame_ptr, process, copy_locals, lineno)?;
+
+    Ok(StackTrace {
+        pid: 0,
+        frames,
+        thread_id: thread.thread_id(),
+        thread_name: None,
+        owns_gil: false,
+        active: true,
+        os_thread_id: thread.native_thread_id(),
+        process_info: None,
+    })
+}
+
+/// Gets Python frames starting from an arbitrary frame pointer. This is used for
+/// suspended coroutine frames as well as regular thread stacks.
+pub(crate) fn get_stack_frames<F, P>(
+    mut frame_ptr: *mut F,
+    process: &P,
+    copy_locals: bool,
+    lineno: LineNo,
+) -> Result<Vec<Frame>, Error>
+where
+    F: FrameObject,
+    P: ProcessMemory,
+{
+    let mut frames = Vec::new();
 
     // We are iterating in reverse, i.e. from last call to first call.
     // Since Python 3.12, there are shim frames inserted before a block
@@ -233,16 +257,7 @@ where
     // First frame is always a shim
     set_last_frame_as_shim_entry(&mut frames);
 
-    Ok(StackTrace {
-        pid: 0,
-        frames,
-        thread_id: thread.thread_id(),
-        thread_name: None,
-        owns_gil: false,
-        active: true,
-        os_thread_id: thread.native_thread_id(),
-        process_info: None,
-    })
+    Ok(frames)
 }
 
 impl StackTrace {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -167,6 +167,45 @@ fn test_thread_names() {
 }
 
 #[test]
+fn test_asyncio_tasks() {
+    #[cfg(target_os = "macos")]
+    {
+        // We need root permissions here to read another process on macOS.
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+    }
+
+    let mut runner = TestRunner::new(Config::default(), "./tests/scripts/asyncio_tasks.py");
+    if runner.spy.version.major != 3 || runner.spy.version.minor < 7 {
+        return;
+    }
+
+    let tasks = runner.spy.get_asyncio_tasks().unwrap();
+    let named: std::collections::HashMap<_, _> = tasks
+        .iter()
+        .filter_map(|task| task.name.as_ref().map(|name| (name.as_str(), task)))
+        .collect();
+
+    let nested = named.get("nested-worker").expect("missing nested-worker");
+    assert_eq!(nested.state, "pending");
+    assert_eq!(nested.frames[0].name, "nested_worker");
+    assert_eq!(nested.frames[0].line, 9);
+    let creation_traceback = nested
+        .creation_traceback
+        .as_ref()
+        .expect("missing nested-worker creation traceback");
+    assert!(creation_traceback
+        .iter()
+        .any(|frame| frame.name == "main" && frame.line == 15));
+
+    let sleeping = named.get("sleep-worker").expect("missing sleep-worker");
+    assert_eq!(sleeping.state, "pending");
+    assert_eq!(sleeping.frames[0].name, "sleep");
+    assert!(sleeping.creation_traceback.is_some());
+}
+
+#[test]
 fn test_recursive() {
     #[cfg(target_os = "macos")]
     {

--- a/tests/scripts/asyncio_tasks.py
+++ b/tests/scripts/asyncio_tasks.py
@@ -1,0 +1,21 @@
+import asyncio
+
+
+async def wait_for_event(event):
+    await event.wait()
+
+
+async def nested_worker(event):
+    await wait_for_event(event)
+
+
+async def main():
+    asyncio.get_running_loop().set_debug(True)
+    event = asyncio.Event()
+    asyncio.create_task(nested_worker(event), name="nested-worker")
+    asyncio.create_task(asyncio.sleep(3600), name="sleep-worker")
+    print("ready", flush=True)
+    await event.wait()
+
+
+asyncio.run(main())


### PR DESCRIPTION
Thanks so much for this project, I absolutely love it and use it all the time!

I implemented (read: claude / codex implemented) this asyncio task support which can pull out all the asyncio tasks.


```
The additional `Asyncio Tasks` section includes each task's id, name, state,
the frame where its coroutine is currently running or suspended, and its
creation traceback when available. CPython only records creation tracebacks
for tasks created while asyncio debug mode is enabled (for example with
`PYTHONASYNCIODEBUG=1`, `asyncio.run(..., debug=True)`, or
`loop.set_debug(True)`). It works with CPython 3.7 through 3.14 and can be
combined with `--locals`. With `--asyncio --json`, the output is an object
containing `threads` and `asyncio_tasks`; JSON output without `--asyncio`
retains py-spy's original array format.
```

(If you're interested in this I'll remove the README change saying this is a fork)