### PR TITLE
fix: avoid colons in default recording filenames

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ use config::{Config, FileFormat, RecordDuration};
 use console_viewer::ConsoleViewer;
 use stack_trace::{Frame, StackTrace};
 
-use chrono::{Local, SecondsFormat};
+use chrono::Local;
 
 #[cfg(unix)]
 fn permission_denied(err: &Error) -> bool {
@@ -130,6 +130,31 @@ impl Recorder for RawFlamegraph {
     }
 }
 
+fn output_filename(config: &Config) -> Result<String, Error> {
+    let filename = match config.filename.clone() {
+        Some(filename) => filename,
+        None => {
+            let ext = match config.format.as_ref() {
+                Some(FileFormat::flamegraph) => "svg",
+                Some(FileFormat::speedscope) => "json",
+                Some(FileFormat::raw) => "txt",
+                Some(FileFormat::chrometrace) => "json",
+                None => return Err(format_err!("A file format is required to record samples")),
+            };
+            let local_time = Local::now().format("%Y-%m-%dT%H-%M-%S%z");
+            let name = match config.python_program.as_ref() {
+                Some(prog) => prog[0].to_string(),
+                None => match config.pid.as_ref() {
+                    Some(pid) => pid.to_string(),
+                    None => String::from("unknown"),
+                },
+            };
+            format!("{name}-{local_time}.{ext}")
+        }
+    };
+    Ok(filename)
+}
+
 fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error> {
     let mut output: Box<dyn Recorder> = match config.format {
         Some(FileFormat::flamegraph) => {
@@ -145,27 +170,7 @@ fn record_samples(pid: remoteprocess::Pid, config: &Config) -> Result<(), Error>
         None => return Err(format_err!("A file format is required to record samples")),
     };
 
-    let filename = match config.filename.clone() {
-        Some(filename) => filename,
-        None => {
-            let ext = match config.format.as_ref() {
-                Some(FileFormat::flamegraph) => "svg",
-                Some(FileFormat::speedscope) => "json",
-                Some(FileFormat::raw) => "txt",
-                Some(FileFormat::chrometrace) => "json",
-                None => return Err(format_err!("A file format is required to record samples")),
-            };
-            let local_time = Local::now().to_rfc3339_opts(SecondsFormat::Secs, true);
-            let name = match config.python_program.as_ref() {
-                Some(prog) => prog[0].to_string(),
-                None => match config.pid.as_ref() {
-                    Some(pid) => pid.to_string(),
-                    None => String::from("unknown"),
-                },
-            };
-            format!("{name}-{local_time}.{ext}")
-        }
-    };
+    let filename = output_filename(config)?;
 
     let sampler = sampler::Sampler::new(pid, config)?;
 
@@ -511,5 +516,73 @@ fn main() {
 
         eprintln!("Error: {:?}", err);
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod filename_tests {
+    use super::*;
+
+    #[test]
+    fn default_output_filename_has_no_colons() {
+        for format in [
+            FileFormat::flamegraph,
+            FileFormat::raw,
+            FileFormat::speedscope,
+            FileFormat::chrometrace,
+        ] {
+            let config = Config {
+                pid: Some(123),
+                format: Some(format),
+                ..Default::default()
+            };
+            let filename = output_filename(&config).unwrap();
+            assert!(
+                !filename.contains(':'),
+                "invalid output filename: {filename}"
+            );
+            assert!(filename.starts_with("123-"));
+            let extension = match format {
+                FileFormat::flamegraph => ".svg",
+                FileFormat::raw => ".txt",
+                FileFormat::speedscope | FileFormat::chrometrace => ".json",
+            };
+            assert!(filename.ends_with(extension));
+            let timestamp = filename
+                .strip_prefix("123-")
+                .unwrap()
+                .strip_suffix(extension)
+                .unwrap();
+            chrono::DateTime::parse_from_str(timestamp, "%Y-%m-%dT%H-%M-%S%z")
+                .expect("filename includes a date, time and timezone offset");
+        }
+    }
+
+    #[test]
+    fn default_output_filename_uses_program_name() {
+        let config = Config {
+            python_program: Some(vec!["python3".to_owned(), "script.py".to_owned()]),
+            format: Some(FileFormat::raw),
+            ..Default::default()
+        };
+        let filename = output_filename(&config).unwrap();
+        assert!(filename.starts_with("python3-"));
+        assert!(
+            !filename.contains(':'),
+            "invalid output filename: {filename}"
+        );
+        assert!(filename.ends_with(".txt"));
+    }
+
+    #[test]
+    fn explicit_output_filename_is_unchanged() {
+        let config = Config {
+            filename: Some("profiles/custom:name.json".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(
+            output_filename(&config).unwrap(),
+            "profiles/custom:name.json"
+        );
     }
 }


### PR DESCRIPTION
The automatically generated recording filename currently uses an RFC 3339 timestamp with colons. Windows rejects these filenames, so a recording without `--output` can fail when writing its result.

Use a timestamp with hyphens between time components and a compact timezone offset, for example `python3-2026-09-08T23-24-05+0800.svg`. The local date, time to seconds, program/PID prefix, and format extension are retained. Explicit output paths are unchanged. Filename selection is extracted into a small helper so it can be tested without attaching to a process.

Validation on Linux with Rust 1.98.0 and Python 3.11.2:
- Two filename regressions fail before the format change and pass after it.
- Four output formats and positive/negative timezone offsets produce nonempty, parseable files while profiling synthetic child processes; explicit filenames remain unchanged.
- Debug and release test runs each pass 44 tests with one existing Python-version-dependent test explicitly excluded.
- Release binary/examples and library without default features build successfully; format, cargo check, and codespell checks pass.
- The existing `test_negative_linenumber_increment` expects `<listcomp>` but receives `f.<locals>.<listcomp>` on Python 3.11.2. The same failure occurs at the unchanged base revision.

Windows filesystem and macOS auto-open behavior have not been exercised locally.

Refs #560 and #482.
